### PR TITLE
Fixes for 20240325

### DIFF
--- a/src/bpf/profiler.bpf.c
+++ b/src/bpf/profiler.bpf.c
@@ -385,7 +385,8 @@ static __always_inline void add_stack(struct bpf_perf_event_data *ctx,
     LOG("[error] bpf_map_update_elem with ret: %d", err);
   }
 
-  u32 zero = 0;
+  // Making this u64 avoid upsetting the eBPF verifier
+  u64 zero = 0;
   u64 *scount = bpf_map_lookup_or_try_init(&aggregated_stacks,
                                            &unwind_state->stack_key, &zero);
   if (scount) {

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -449,7 +449,9 @@ impl Collector {
 // Static config
 const MAX_UNWIND_INFO_SHARDS: u64 = 50;
 const SHARD_CAPACITY: usize = MAX_UNWIND_TABLE_SIZE as usize;
-const PERF_BUFFER_PAGES: usize = 512 * 1024;
+// Make each perf buffer 512 KB
+// TODO: should make this configurable via a command line argument in future
+const PERF_BUFFER_BYTES: usize = 512 * 1024;
 
 #[allow(dead_code)]
 pub struct RawAggregatedSample {
@@ -552,7 +554,7 @@ impl Profiler<'_> {
 
         let chan_send = self.chan_send.clone();
         let perf_buffer = PerfBufferBuilder::new(self.bpf.maps().events())
-            .pages(PERF_BUFFER_PAGES / page_size::get())
+            .pages(PERF_BUFFER_BYTES / page_size::get())
             .sample_cb(move |cpu: i32, data: &[u8]| {
                 Self::handle_event(&chan_send, cpu, data);
             })


### PR DESCRIPTION
This fixes 2 separate issues:

1. The eBPF verifier in newer kernels requires all items on the stack to be fully initialized.  This generally requires all values on the stack to be 64 bit values, or a multiple of 64 bits.  Using u64 variables rather than u32 guarantees we won't have issues at present.
2. The variable name PERF_BUFFER_PAGES stores a value that is actually in units of bytes, so changing the name to PERF_BUFFER_BYTES