### PR TITLE
Run test in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,14 @@ jobs:
     - uses: actions/checkout@main
     - uses: DeterminateSystems/nix-installer-action@main
     - uses: DeterminateSystems/magic-nix-cache-action@main
-    - name: Run `cargo check`
-      run: nix develop --command cargo check
+    - name: Set up nix dev env
+      run: nix develop --command echo 0
+    - name: Run `cargo build`
+      run: nix develop --command cargo build
     - name: Run `cargo clippy`
       run: nix develop --command cargo clippy --all-targets -- -D warnings
+    - name: Run `cargo test`
+      run: nix develop --command cargo test
     - name: Run `cargo fmt`
       run: nix develop --command cargo fmt --check
     - name: Run `nix fmt`

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ struct Cli {
     )]
     show_unwind_info: Option<String>,
     /// Show build ID for given binary
-    #[arg(long, value_name = "PATH_TO_BINARY", 
+    #[arg(long, value_name = "PATH_TO_BINARY",
         conflicts_with_all = ["pids", "tids", "duration", "filter_logs",
             "sample_freq", "flamegraph_file"]
     )]
@@ -163,7 +163,7 @@ mod tests {
 
         cmd.arg("--help");
         let expected = expect![[r#"
-            "Usage: lightswitch [OPTIONS]\n\nOptions:\n      --pids <PIDS>\n          Specific PIDs to profile\n      --tids <TIDS>\n          Specific TIDs to profile (these can be outside the PIDs selected above)\n      --show-unwind-info <PATH_TO_BINARY>\n          Show unwind info for given binary\n      --show-info <PATH_TO_BINARY>\n          Show build ID for given binary\n  -D, --duration <DURATION>\n          How long this agent will run in seconds [default: 18446744073709551615]\n      --filter-logs\n          \n      --sample-freq <SAMPLE_FREQ_IN_HZ>\n          Per-CPU Sampling Frequency in Hz [default: 19]\n      --flamegraph-file <FLAMEGRAPH_FILE>\n          Output file for Flame Graph in SVG format [default: flame.svg]\n  -h, --help\n          Print help\n"
+            "Usage: lightswitch [OPTIONS]\n\nOptions:\n      --pids <PIDS>\n          Specific PIDs to profile\n      --tids <TIDS>\n          Specific TIDs to profile (these can be outside the PIDs selected above)\n      --show-unwind-info <PATH_TO_BINARY>\n          Show unwind info for given binary\n      --show-info <PATH_TO_BINARY>\n          Show build ID for given binary\n  -D, --duration <DURATION>\n          How long this agent will run in seconds [default: 18446744073709551615]\n      --filter-logs\n          Enable TRACE (max) level logging - defaults to INFO level otherwise\n      --sample-freq <SAMPLE_FREQ_IN_HZ>\n          Per-CPU Sampling Frequency in Hz [default: 19]\n      --flamegraph-file <FLAMEGRAPH_FILE>\n          Output file for Flame Graph in SVG format [default: flame.svg]\n  -h, --help\n          Print help\n"
         "#]];
         cmd.assert().success();
         let actual = String::from_utf8(cmd.unwrap().stdout).unwrap();


### PR DESCRIPTION
- cli: Update snapshot tests
- ci: Run tests

We were not running tests in ci, so fix this, also add a step just to
enter the nix dev environment so the we know how long does it take to
pull / build our native dependencies and tooling.

Also changing `check` -> `build` as the CLI integration tests require
the debug binary to be built. This is a bit janky and we should have
better integration with the build system. We'll change this later on.

Test Plan
=========

ci :)