### PR TITLE
Replace expect-test with insta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,12 +417,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
-name = "dissimilar"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e3bdc80eee6e16b2b6b0f87fbc98c04bee3455e35174c0de1a125d0688c632"
-
-[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +427,12 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "env_logger"
@@ -445,16 +457,6 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "expect-test"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d9eafeadd538e68fb28016364c9732d78e420b9ff8853fa5e4058861e9f8d3"
-dependencies = [
- "dissimilar",
- "once_cell",
 ]
 
 [[package]]
@@ -704,6 +706,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eab73f58e59ca6526037208f0e98851159ec1633cf17b6cd2e1f2c3fd5d53cc"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "serde",
+ "similar",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,9 +844,9 @@ dependencies = [
  "clap",
  "data-encoding",
  "errno",
- "expect-test",
  "gimli",
  "inferno",
+ "insta",
  "lazy_static",
  "libbpf-cargo",
  "libbpf-rs",
@@ -850,6 +865,12 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1490,6 +1511,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "similar"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ primal = "0.3.2"
 assert_cmd = { version = "2.0.14" }
 insta = { version = "1.38.0", features = ["yaml"] }
 rstest = "0.18.2"
-# cargo-insta = "1.38.0"
 
 [build-dependencies]
 bindgen = "0.69.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,14 @@ primal = "0.3.2"
 
 [dev-dependencies]
 assert_cmd = { version = "2.0.14" }
-expect-test = { version = "1.4.1" }
+insta = { version = "1.38.0", features = ["yaml"] }
 rstest = "0.18.2"
+# cargo-insta = "1.38.0"
 
 [build-dependencies]
 bindgen = "0.69.4"
 libbpf-cargo = "0.22.1"
+
+[profile.dev.package]
+insta.opt-level = 3
+similar.opt-level = 3

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,8 @@
               openssl
               # Other tools
               cargo-edit
+              # snapshot testing plugin binary
+              cargo-insta
               # ocamlPackages.magic-trace
             ];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,6 @@ mod tests {
     use super::Cli;
     use assert_cmd::Command;
     use clap::Parser;
-    use expect_test::expect;
     use rstest::rstest;
 
     #[test]
@@ -194,13 +193,12 @@ mod tests {
         let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
 
         cmd.arg("--help");
-        let expected = expect![[r#"
-            "Usage: lightswitch [OPTIONS]\n\nOptions:\n      --pids <PIDS>\n          Specific PIDs to profile\n      --tids <TIDS>\n          Specific TIDs to profile (these can be outside the PIDs selected above)\n      --show-unwind-info <PATH_TO_BINARY>\n          Show unwind info for given binary\n      --show-info <PATH_TO_BINARY>\n          Show build ID for given binary\n  -D, --duration <DURATION>\n          How long this agent will run in seconds [default: 18446744073709551615]\n      --filter-logs\n          Enable TRACE (max) level logging - defaults to INFO level otherwise\n      --sample-freq <SAMPLE_FREQ_IN_HZ>\n          Per-CPU Sampling Frequency in Hz [default: 19]\n      --flamegraph-file <FLAMEGRAPH_FILE>\n          Output file for Flame Graph in SVG format [default: flame.svg]\n  -h, --help\n          Print help\n"
-        "#]];
         cmd.assert().success();
         let actual = String::from_utf8(cmd.unwrap().stdout).unwrap();
-        expected.assert_debug_eq(&actual);
-        // cmd.assert().stdout(predicate::str::contains("junk"));
+        insta::assert_yaml_snapshot!(actual, @r###"
+        ---
+        "Usage: lightswitch [OPTIONS]\n\nOptions:\n      --pids <PIDS>\n          Specific PIDs to profile\n      --tids <TIDS>\n          Specific TIDs to profile (these can be outside the PIDs selected above)\n      --show-unwind-info <PATH_TO_BINARY>\n          Show unwind info for given binary\n      --show-info <PATH_TO_BINARY>\n          Show build ID for given binary\n  -D, --duration <DURATION>\n          How long this agent will run in seconds [default: 18446744073709551615]\n      --filter-logs\n          Enable TRACE (max) level logging - defaults to INFO level otherwise\n      --sample-freq <SAMPLE_FREQ_IN_HZ>\n          Per-CPU Sampling Frequency in Hz [default: 19]\n      --flamegraph-file <FLAMEGRAPH_FILE>\n          Output file for Flame Graph in SVG format [default: flame.svg]\n  -h, --help\n          Print help\n"
+        "###);
     }
 
     #[rstest]


### PR DESCRIPTION
Instead of using [expect-test](https://crates.io/crates/expect-test), utilize the [insta](https://crates.io/crates/insta) crate for snapshot testing.

Benefits:
- Can use a variety of ways to encode a snapshot literal
- Can store snapshots inline or in individual files as desired
- Dedicated cargo command to interact with/update  snapshots

Things not yet dealt with in this PR:
- ~~[Continuous Integration](https://insta.rs/docs/quickstart/#continuous-integration) setting needs to be configured~~ - this is automatically set by Github as a default env variable - nothing to do here.
- The [cargo-insta](https://crates.io/crates/cargo-insta) binary plugin crate still needs to be integrated/uncommented in Cargo.toml or some other way so that the plugin is automatically installed if missing.