### PR TITLE
Give helpful hint if sampling frequency isn't prime

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,9 +38,39 @@ fn sample_freq_in_range(s: &str) -> Result<u16, String> {
         ));
     }
     if !is_prime(sample_freq.try_into().unwrap()) {
-        return Err("sample frequency is not prime".to_string());
+        // return Err("sample frequency is not prime".to_string());
+        let ba_result = primes_before_after(sample_freq.try_into().unwrap());
+        match ba_result {
+            Ok((prime_before, prime_after)) => {
+                println!(
+                    "Should use a prime number for sample frequency: {} < {} < {}",
+                    prime_before, sample_freq, prime_after
+                );
+            }
+            Err(_) => println!("primes_before_after should not have failed"),
+        }
     }
     Ok(sample_freq as u16)
+}
+
+/// Given a non-prime unsigned int, return the prime number that precedes it
+/// as well as the prime that succeeds it
+fn primes_before_after(non_prime: usize) -> Result<(usize, usize), String> {
+    // If a prime number passed in, return Err
+    if is_prime(non_prime.try_into().unwrap()) {
+        return Err(format!("{} IS prime", non_prime));
+    }
+    // Find all primes up to the one past our non_prime number
+    // First, use an iterator, which should be slower (benchmark this)
+    // let primes1 = primal::Primes::all().take_while(|p| *p < non_prime * 2);
+    // Now, use a primal sieve, which should be faster
+    // let primes2 = primal::StreamingSieve::take_while(|p| *p < non_prime * 2);
+    // What is the count (not value) of the prime just before non_prime?
+    let n_before: usize = primal::StreamingSieve::prime_pi(non_prime);
+    let n_after: usize = n_before + 1;
+    let before = primal::StreamingSieve::nth_prime(n_before);
+    let after = primal::StreamingSieve::nth_prime(n_after);
+    Ok((before, after))
 }
 
 #[derive(Parser, Debug)]
@@ -177,6 +207,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 #[cfg(test)]
 mod tests {
+    use crate::primes_before_after;
+
     use super::Cli;
     use assert_cmd::Command;
     use clap::Parser;
@@ -238,4 +270,44 @@ mod tests {
         }
         // Expected output/results for various inputs
     }
+
+    #[rstest]
+    #[case(49, (47,53), "")]
+    #[case(97, (0, 0), "97 IS prime")]
+    #[case(100, (97,101), "")]
+    #[case(398, (397,401), "")]
+    #[case(500, (499,503), "")]
+    #[case(1000, (997, 1009), "")]
+    #[case(1001, (997, 1009), "")]
+    #[case(1009, (0, 0), "1009 IS prime")]
+    fn test_primes_before_after(
+        #[case] non_prime: usize,
+        #[case] expected_tuple: (usize, usize),
+        #[case] expected_msg: String,
+    ) {
+        let actual_result = primes_before_after(non_prime);
+        match actual_result {
+            Ok(tuple) => {
+                assert_eq!(tuple.0, expected_tuple.0);
+                assert_eq!(tuple.1, expected_tuple.1);
+            }
+            Err(err) => {
+                let actual_message = err.to_string();
+                assert!(actual_message.contains(expected_msg.as_str()));
+            }
+        }
+    }
+
+    // Only usable on the nightly toolchain for now...
+    // use test::{black_box, Bencher};
+
+    // #[bench]
+    // fn bench_primes_before_after(b: &mut Bencher) {
+    //     b.iter(|| {
+    //         // Inner closure, the actual test
+    //         for i in 1..1009 {
+    //             black_box(primes_before_after(i));
+    //         }
+    //     });
+    // }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ fn sample_freq_in_range(s: &str) -> Result<u16, String> {
         ));
     }
     if !is_prime(sample_freq.try_into().unwrap()) {
-        let ba_result = primes_before_after(sample_freq.try_into().unwrap());
+        let ba_result = primes_before_after(sample_freq);
         match ba_result {
             Ok((prime_before, prime_after)) => {
                 return Err(format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,6 @@ fn sample_freq_in_range(s: &str) -> Result<u16, String> {
         ));
     }
     if !is_prime(sample_freq.try_into().unwrap()) {
-        // return Err("sample frequency is not prime".to_string());
         let ba_result = primes_before_after(sample_freq.try_into().unwrap());
         match ba_result {
             Ok((prime_before, prime_after)) => {
@@ -46,10 +45,6 @@ fn sample_freq_in_range(s: &str) -> Result<u16, String> {
                     "Sample frequency {} is not prime - use {} (before) or {} (after) instead",
                     sample_freq, prime_before, prime_after
                 ));
-                // println!(
-                //     "Should use a prime number for sample frequency: {} < {} < {}",
-                //     prime_before, sample_freq, prime_after
-                // );
             }
             Err(_) => println!("primes_before_after should not have failed"),
         }
@@ -207,9 +202,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::primes_before_after;
-
-    use super::Cli;
+    use super::*;
     use assert_cmd::Command;
     use clap::Parser;
     use rstest::rstest;
@@ -253,6 +246,7 @@ mod tests {
     #[case::prime_1009("1009", "")]
     #[case::non_prime_out_of_range1010("1010", "sample frequency not in allowed range")]
     #[case::prime_out_of_range_1013("1013", "sample frequency not in allowed range")]
+    #[trace]
     fn sample_freq_successes(#[case] desired_freq: String, #[case] expected_msg: String) {
         let execname = env!("CARGO_PKG_NAME");
         let argname = "--sample-freq";

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,10 +42,14 @@ fn sample_freq_in_range(s: &str) -> Result<u16, String> {
         let ba_result = primes_before_after(sample_freq.try_into().unwrap());
         match ba_result {
             Ok((prime_before, prime_after)) => {
-                println!(
-                    "Should use a prime number for sample frequency: {} < {} < {}",
-                    prime_before, sample_freq, prime_after
-                );
+                return Err(format!(
+                    "Sample frequency {} is not prime - use {} (before) or {} (after) instead",
+                    sample_freq, prime_before, prime_after
+                ));
+                // println!(
+                //     "Should use a prime number for sample frequency: {} < {} < {}",
+                //     prime_before, sample_freq, prime_after
+                // );
             }
             Err(_) => println!("primes_before_after should not have failed"),
         }
@@ -60,13 +64,9 @@ fn primes_before_after(non_prime: usize) -> Result<(usize, usize), String> {
     if is_prime(non_prime.try_into().unwrap()) {
         return Err(format!("{} IS prime", non_prime));
     }
-    // Find all primes up to the one past our non_prime number
-    // First, use an iterator, which should be slower (benchmark this)
-    // let primes1 = primal::Primes::all().take_while(|p| *p < non_prime * 2);
-    // Now, use a primal sieve, which should be faster
-    // let primes2 = primal::StreamingSieve::take_while(|p| *p < non_prime * 2);
-    // What is the count (not value) of the prime just before non_prime?
+    // What is the count (not value) of the prime just before our non_prime?
     let n_before: usize = primal::StreamingSieve::prime_pi(non_prime);
+    // And the count of the prime just after our non_prime?
     let n_after: usize = n_before + 1;
     let before = primal::StreamingSieve::nth_prime(n_before);
     let after = primal::StreamingSieve::nth_prime(n_after);
@@ -240,9 +240,15 @@ mod tests {
     #[should_panic]
     #[case::neg101("-101", "sample frequency not in allowed range")]
     #[case::prime_19("19", "")]
-    #[case::non_prime_20("20", "sample frequency is not prime")]
+    #[case::non_prime_20(
+        "20",
+        "Sample frequency 20 is not prime - use 19 (before) or 23 (after) instead"
+    )]
     #[case::prime_47("47", "")]
-    #[case::non_prime_49("49", "sample frequency is not prime")]
+    #[case::non_prime_49(
+        "49",
+        "Sample frequency 49 is not prime - use 47 (before) or 53 (after) instead"
+    )]
     #[case::prime_101("101", "")]
     #[case::prime_1009("1009", "")]
     #[case::non_prime_out_of_range1010("1010", "sample frequency not in allowed range")]
@@ -266,7 +272,6 @@ mod tests {
                 assert!(actual_message.contains(expected_msg.as_str()));
             }
         }
-        // Expected output/results for various inputs
     }
 
     #[rstest]


### PR DESCRIPTION
Currently, we exit with error if the `--sample-freq` option is provided with a non-prime number.

This prevents accidentally sampling at rates that could collide with other system events more easily, leading to unintended feedback.

But, it doesn't help the user know what numbers they should have picked.

This PR adjusts the error message to include the prime numbers below and above the sampling rate that was requested.