### PR TITLE
Mappings redesign

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,7 @@ fn main() {
     println!("cargo:rerun-if-changed={PROFILER_BPF_SOURCE}");
 
     let bindings = bindgen::Builder::default()
+        .derive_default(true)
         .header(PROFILER_BPF_HEADER)
         .generate()
         .expect("Unable to generate bindings");

--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -44,6 +44,7 @@ _Static_assert(1 << MAX_BINARY_SEARCH_DEPTH >= MAX_UNWIND_TABLE_SIZE,
 #define CFA_TYPE_EXPRESSION 3
 // Special values.
 #define CFA_TYPE_END_OF_FDE_MARKER 4
+#define CFA_TYPE_OFFSET_DID_NOT_FIT 5
 
 // Values for the unwind table's frame pointer type.
 #define RBP_TYPE_UNCHANGED 0
@@ -132,11 +133,22 @@ typedef struct {
   u64 end;
 } mapping_t;
 
+// Key for the longest prefix matching. This is defined
+// in the kernel in struct bpf_lpm_trie_key.
+struct exec_mappings_key {
+  u32 prefix_len;
+  u32 pid;
+  u64 data;
+};
+
+// Prefix size in bits, excluding the prefix length.
+#define PREFIX_LEN (sizeof(struct exec_mappings_key) - sizeof(u32)) * 8;
+
 // Executable mappings for a process.
 typedef struct {
   u32 is_jit_compiler;
-  u32 len;
-  mapping_t mappings[MAX_MAPPINGS_PER_PROCESS];
+  //u32 len;
+  // mapping_t mappings[MAX_MAPPINGS_PER_PROCESS];
 } process_info_t;
 
 // A row in the stack unwinding table for x86_64.

--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -144,13 +144,6 @@ struct exec_mappings_key {
 // Prefix size in bits, excluding the prefix length.
 #define PREFIX_LEN (sizeof(struct exec_mappings_key) - sizeof(u32)) * 8;
 
-// Executable mappings for a process.
-typedef struct {
-  u32 is_jit_compiler;
-  //u32 len;
-  // mapping_t mappings[MAX_MAPPINGS_PER_PROCESS];
-} process_info_t;
-
 // A row in the stack unwinding table for x86_64.
 typedef struct __attribute__((packed)) {
   u64 pc;

--- a/src/bpf/profiler_bindings.rs
+++ b/src/bpf/profiler_bindings.rs
@@ -13,6 +13,18 @@ unsafe impl Plain for Event {}
 unsafe impl Plain for process_info_t {}
 unsafe impl Plain for unwind_info_chunks_t {}
 unsafe impl Plain for unwinder_stats_t {}
+unsafe impl Plain for exec_mappings_key {}
+unsafe impl Plain for mapping_t {}
+
+impl exec_mappings_key {
+    pub fn new(pid: u32, address: u64, prefix: u32) -> Self {
+        Self {
+            prefix_len: 32 + prefix,
+            pid: pid.to_be(),
+            data: address.to_be(),
+        }
+    }
+}
 
 impl Add for unwinder_stats_t {
     type Output = Self;

--- a/src/bpf/profiler_bindings.rs
+++ b/src/bpf/profiler_bindings.rs
@@ -10,7 +10,6 @@ include!(concat!(env!("OUT_DIR"), "/profiler_bindings.rs"));
 unsafe impl Plain for stack_count_key_t {}
 unsafe impl Plain for native_stack_t {}
 unsafe impl Plain for Event {}
-unsafe impl Plain for process_info_t {}
 unsafe impl Plain for unwind_info_chunks_t {}
 unsafe impl Plain for unwinder_stats_t {}
 unsafe impl Plain for exec_mappings_key {}
@@ -45,36 +44,6 @@ impl Add for unwinder_stats_t {
                 + other.error_should_never_happen,
             error_pc_not_covered: self.error_pc_not_covered + other.error_pc_not_covered,
             error_jit: self.error_jit + other.error_jit,
-        }
-    }
-}
-
-#[allow(clippy::derivable_impls)]
-impl Default for unwinder_stats_t {
-    fn default() -> Self {
-        Self {
-            total: 0,
-            success_dwarf: 0,
-            error_truncated: 0,
-            error_unsupported_expression: 0,
-            error_unsupported_frame_pointer_action: 0,
-            error_unsupported_cfa_register: 0,
-            error_catchall: 0,
-            error_should_never_happen: 0,
-            error_pc_not_covered: 0,
-            error_jit: 0,
-        }
-    }
-}
-
-#[allow(clippy::derivable_impls)]
-impl Default for stack_count_key_t {
-    fn default() -> Self {
-        Self {
-            task_id: 0,
-            pid: 0,
-            user_stack_id: 0,
-            kernel_stack_id: 0,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,3 +7,4 @@ pub mod profile;
 pub mod profiler;
 pub mod unwind_info;
 pub mod usym;
+pub mod util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let collector = Collector::new();
 
-    let mut p: Profiler<'_> = Profiler::new(false, args.duration, args.sample_freq);
+    let mut p: Profiler<'_> = Profiler::new(true, args.duration, args.sample_freq);
     p.profile_pids(args.pids);
     p.run(collector.clone());
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,153 @@
+#[derive(Debug, PartialEq)]
+pub struct AddressBlockRange {
+    pub addr: u64,
+    pub range: u32,
+}
+
+/// For a given address range, calculate all the prefix ranges to ensure searching
+/// with Longest Prefix Match returns the precise value we want. This is typically
+/// used in networking to select the right subnet.
+pub fn summarize_address_range(low: u64, high: u64) -> Vec<AddressBlockRange> {
+    let mut res = Vec::new();
+    let mut curr = low;
+
+    if low > high {
+        panic!("first {:x} > last {:x}", low, high);
+    }
+
+    while curr <= high {
+        let number_of_bits = std::cmp::min(
+            curr.trailing_zeros(),
+            (64 - (high - curr + 1).leading_zeros()) - 1,
+        );
+        res.push(AddressBlockRange {
+            addr: curr,
+            range: 64 - number_of_bits,
+        });
+        curr += 1 << number_of_bits;
+        if curr - 1 == u64::MAX {
+            break;
+        }
+    }
+
+    res
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::size_of;
+
+    use libbpf_rs::libbpf_sys;
+    use libbpf_rs::MapFlags;
+    use libbpf_rs::MapHandle;
+    use libbpf_rs::MapType;
+
+    use crate::bpf::profiler_bindings::exec_mappings_key;
+    use crate::bpf::profiler_bindings::mapping_t;
+    use crate::util::*;
+
+    #[test]
+    fn test_summarize_address_range() {
+        assert_eq!(
+            summarize_address_range(0, 100),
+            vec![
+                AddressBlockRange { addr: 0, range: 58 },
+                AddressBlockRange {
+                    addr: 64,
+                    range: 59
+                },
+                AddressBlockRange {
+                    addr: 96,
+                    range: 62
+                },
+                AddressBlockRange {
+                    addr: 100,
+                    range: 64
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn longest_prefix_match_exhaustive_integration_tests() {
+        let opts = libbpf_sys::bpf_map_create_opts {
+            sz: size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
+            map_flags: libbpf_sys::BPF_F_NO_PREALLOC,
+            ..Default::default()
+        };
+
+        let map =
+            MapHandle::create(MapType::LpmTrie, Some("lpm_test_map"), 16, 32, 1024, &opts).unwrap();
+
+        let mapping1 = mapping_t {
+            executable_id: 1111,
+            type_: 1,
+            load_address: 1111,
+            begin: 0x7f7428ea8000,
+            end: 0x7f7428f50000,
+        };
+
+        let mapping2 = mapping_t {
+            executable_id: 2222,
+            type_: 2,
+            load_address: 2222,
+            begin: 0x7f7428f85000,
+            end: 0x7f74290e5000,
+        };
+
+        assert!(mapping1.begin < mapping1.end);
+        assert!(mapping2.begin < mapping2.end);
+        assert!(mapping1.end < mapping2.begin);
+
+        for address_range in summarize_address_range(mapping1.begin, mapping1.end - 1) {
+            let key = exec_mappings_key::new(510530, address_range.addr, address_range.range);
+            map.update(
+                unsafe { plain::as_bytes(&key) },
+                unsafe { plain::as_bytes(&mapping1) },
+                MapFlags::ANY,
+            )
+            .unwrap();
+        }
+
+        for address_range in summarize_address_range(mapping2.begin, mapping2.end - 1) {
+            let key = exec_mappings_key::new(510530, address_range.addr, address_range.range);
+            map.update(
+                unsafe { plain::as_bytes(&key) },
+                unsafe { plain::as_bytes(&mapping2) },
+                MapFlags::ANY,
+            )
+            .unwrap();
+        }
+
+        let mut key = exec_mappings_key::new(510530, 0x0, 32 + 64);
+
+        // Test non existent key.
+        key.data = (0x0_u64).to_be();
+        let retrieved = map
+            .lookup(unsafe { plain::as_bytes(&key) }, MapFlags::ANY)
+            .unwrap();
+        assert_eq!(retrieved, None);
+
+        // First mapping tests.
+        for addr in mapping1.begin..mapping1.end {
+            key.data = addr.to_be();
+            let retrieved = map
+                .lookup(unsafe { plain::as_bytes(&key) }, MapFlags::ANY)
+                .unwrap()
+                .unwrap();
+            let parsed: mapping_t = *plain::from_bytes(&retrieved).unwrap();
+            assert_eq!(parsed.executable_id, mapping1.executable_id);
+        }
+
+        // Second mapping tests.
+        for addr in mapping2.begin..mapping2.end {
+            key.data = addr.to_be();
+            let retrieved = map
+                .lookup(unsafe { plain::as_bytes(&key) }, MapFlags::ANY)
+                .unwrap()
+                .unwrap();
+            let parsed: mapping_t = *plain::from_bytes(&retrieved).unwrap();
+            assert_eq!(parsed.executable_id, mapping2.executable_id);
+        }
+    }
+}


### PR DESCRIPTION

## Redesign mapping storage and search

Rather than keeping a large-ish fixed-size array for every single
process, use the longest prefix match that the BPF trie data structure
provides, this has several benefits.

- Searching is no longer linear the number of mappings;
- The max number of mappings is lifted, and now the total amount of
  mapping entries are shared among the processes, so processes that have
few mappings will have few entries, while processes with lots of
mappings can have more entries than the current maximum, allowing
lightswitch to profile more applications;

### Future work

There are no counters in BPF or userspace in case of errors. There are a
bunch of areas in the code that can panic, such as map operations that
will fail if the maps are full.

### Test Plan

Added unit and integration tests, as well as ran this commit for several
hours with many different processes without issues.

# Rework known process detection
We don't need a separate map anymore. As BPF tracing programs require
hash maps to be preallocated, this will save some memory.

Something we might want to do in the future is tune the maximum entries
in the mappings BPF map.

Additionally, this also cleans up some of the implementations for the
BPF bindings. I love bindgen!!

### Test Plan

Ran locally without any issues or errors.
