### PR TITLE
bpf: Promote warnings to errors and tidy code

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -50,14 +50,14 @@ fn main() {
     let skel = Path::new(PROFILER_SKELETON);
     SkeletonBuilder::new()
         .source(PROFILER_BPF_SOURCE)
-        .clang_args("-Wextra -Wall")
+        .clang_args("-Wextra -Wall -Werror -Wno-unused-command-line-argument")
         .build_and_generate(skel)
         .expect("run skeleton builder");
 
     let skel = Path::new(TRACERS_SKELETON);
     SkeletonBuilder::new()
         .source(TRACERS_BPF_SOURCE)
-        .clang_args("-Wextra -Wall")
+        .clang_args("-Wextra -Wall -Werror -Wno-unused-command-line-argument -Wno-unused-function")
         .build_and_generate(skel)
         .expect("run skeleton builder");
 }

--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -205,7 +205,7 @@ unsigned long long hash_stack(native_stack_t *stack) {
 
   unsigned long long hash = seed ^ (stack->len * m);
 
-  for (int i = 0; i < MAX_STACK_DEPTH; i++) {
+  for (unsigned long long i = 0; i < MAX_STACK_DEPTH; i++) {
     // The stack is not zeroed when we initialise it, we simply
     // set the length to zero. This is a workaround to produce
     // the same hash for two stacks that might have garbage values

--- a/src/bpf/tracers.bpf.c
+++ b/src/bpf/tracers.bpf.c
@@ -55,6 +55,8 @@ int tracer_process_exit(void *ctx) {
     if (bpf_perf_event_output(ctx, &tracer_events, BPF_F_CURRENT_CPU, &event, sizeof(tracer_event_t)) < 0) {
         LOG("[error] failed to send process exit tracer event");
     }
+
+    return 0;
 }
 
 SEC("tracepoint/syscalls/sys_enter_munmap")


### PR DESCRIPTION
Some of the code to fetch the userspace registers from a kernel context were duplicated for some reason and the function wasn't used. This wasn't caught before because we didn't make warnings errors.

Also make some other small code cleanups.

Test Plan
=======

<img width="978" alt="image" src="https://github.com/javierhonduco/lightswitch/assets/959128/1e66f4a4-a1bb-433c-8a6d-be7be60722fa">
