### PR TITLE
Move find_mapping's log to its callsite

### DIFF
--- a/src/bpf/shared_helpers.h
+++ b/src/bpf/shared_helpers.h
@@ -5,21 +5,7 @@ static __always_inline mapping_t* find_mapping(int per_process_id, u64 pc) {
   key.pid = __builtin_bswap32((u32) per_process_id);
   key.data = __builtin_bswap64(pc);
 
-  mapping_t *mapping = bpf_map_lookup_elem(&exec_mappings, &key);
-
-  if (mapping == NULL) {
-    LOG("[error] no mapping found for pc %llx", pc);
-    bump_unwind_error_mapping_not_found();
-    return NULL;
-  }
-
-  if (pc < mapping->begin || pc >= mapping->end) {
-    LOG("[error] pc %llx not contained within begin: %llx end: %llx", pc, mapping->begin, mapping->end);
-    bump_unwind_error_mapping_does_not_contain_pc();
-    return NULL;
-  }
-
-  return mapping;
+  return bpf_map_lookup_elem(&exec_mappings, &key);
 }
 
 static __always_inline bool process_is_known(int per_process_id) {


### PR DESCRIPTION
In the unwinder process we want to log if we can't find a mapping, but in the tracers, we are just checking to see whether we should send the event or not. Logging there is not really necessary and it adds lots of noise.