### PR TITLE
Use the right register type in arm64

### DIFF
--- a/src/bpf/profiler.bpf.c
+++ b/src/bpf/profiler.bpf.c
@@ -219,7 +219,7 @@ static __always_inline bool retrieve_task_registers(u64 *ip, u64 *sp, u64 *bp) {
   }
 
   void *ptr = stack + THREAD_SIZE - TOP_OF_KERNEL_STACK_PADDING;
-  struct pt_regs *regs = ((struct pt_regs *)ptr) - 1;
+  bpf_user_pt_regs_t *regs = ((bpf_user_pt_regs_t *)ptr) - 1;
 
   *ip = PT_REGS_IP_CORE(regs);
   *sp = PT_REGS_SP_CORE(regs);
@@ -560,7 +560,7 @@ int dwarf_unwind(struct bpf_perf_event_data *ctx) {
 }
 
 // Set up the initial unwinding state.
-static __always_inline bool set_initial_state(unwind_state_t *unwind_state, struct pt_regs *regs) {
+static __always_inline bool set_initial_state(unwind_state_t *unwind_state, bpf_user_pt_regs_t *regs) {
   unwind_state->stack.len = 0;
   unwind_state->tail_calls = 0;
 


### PR DESCRIPTION
As we were using thhe x86 one, `bpf_user_pt_regs_t` is defined in vmlinux as:

```
typedef struct pt_regs bpf_user_pt_regs_t;
```

in x86 and:

```
typedef struct user_pt_regs bpf_user_pt_regs_t;
```

in arm64

Future work
===========

Ensure `retrieve_task_registers` is correct for arm64 and add kernel tests for this architecture.

Test Plan
=========

Tested on my x86 and arm64 machines.