### PR TITLE
Unwind information performance improvements

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -752,17 +752,9 @@ impl Profiler<'_> {
             }
             span.exit();
 
-            let span: span::EnteredSpan = span!(Level::DEBUG, "sort unwind info").entered();
-            found_unwind_info.sort_by(|a, b| {
-                let a_pc = a.pc;
-                let b_pc = b.pc;
-                a_pc.cmp(&b_pc)
-            });
-            span.exit();
-
             let span: span::EnteredSpan = span!(Level::DEBUG, "optimize unwind info").entered();
-            let found_unwind_info = remove_unnecesary_markers(&found_unwind_info);
-            let found_unwind_info = remove_redundant(&found_unwind_info);
+            remove_unnecesary_markers(&mut found_unwind_info);
+            remove_redundant(&mut found_unwind_info);
             span.exit();
 
             debug!(


### PR DESCRIPTION
This commit:
- sort the FDEs rather than the whole unwind information, which is a smaller vector. This showed no performance changes in benchmarks;
- optimise the unwind info in-place. Most of the performance gains in this commits comes from this changes;

Wrote a benchmark with criterion.rs and saw a ~25% decrease in time spent building and optimising the unwind info.

```
Running benches/unwind_info.rs (target/release/deps/unwind_info-b3269dc277690031)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
unwind info + sorting   time:   [37.697 ms 39.061 ms 40.592 ms]
                        change: [-26.710% -23.315% -19.870%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
```

For this test, this node.js binary was used
```
/home/javierhonduco/.vscode-server/cli/servers/Stable-e170252f762678dec6ca2cc69aba1570769a5d39/server/node: ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, BuildID[sha1]=e034c66a6dc897492d6ecae6c6b046669f94ad96, with debug_info, not stripped, too many notes (256)
```

I am not commiting the benchmarks as I bumped into some rough edges with criterion and I am not sure if it's maintained anymore. Might be worth adding some benchmarks later on.

Test Plan
=========

Compared the unwind info before and after this change for a bunch of executables.