### PR TITLE
build: Disable debuginfod support in readelf

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
           pkgs = import nixpkgs {
             inherit system overlays;
           };
-          elfutils-without-zstd = pkgs.elfutils.overrideAttrs (attrs: {
+          elfutils' = (pkgs.elfutils.override { enableDebuginfod = false; }).overrideAttrs (attrs: {
             configureFlags = attrs.configureFlags ++ [ "--without-zstd" ];
           });
         in
@@ -44,7 +44,7 @@
               # Native deps
               glibc
               glibc.static
-              elfutils-without-zstd
+              elfutils'
               zlib.static
               zlib.dev
               openssl
@@ -63,7 +63,7 @@
             ];
 
             LIBCLANG_PATH = lib.makeLibraryPath [ llvmPackages_16.libclang ];
-            LD_LIBRARY_PATH = lib.makeLibraryPath [ zlib.static elfutils-without-zstd ];
+            LD_LIBRARY_PATH = lib.makeLibraryPath [ zlib.static elfutils' ];
           };
         }
       );


### PR DESCRIPTION
It pulls a bunch of code we don't need, such as a web server.

Test Plan
=========

CI