### PR TITLE
Add derivation to build lightswitch with nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 flame.svg
 src/bpf/*_skel.rs
 .vmtest.log
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1714536327,
+        "narHash": "sha256-zu4+LcygJwdyFHunTMeDFltBZ9+hoWvR/1A7IEy7ChA=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "3124551aebd8db15d4560716d4f903bd44c64e4a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,6 +56,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"


### PR DESCRIPTION
As well as a container image. This is mostly experimental and won't be adding CI for it as of now.

Also add a rust-gdb env variable to use the nix provided gdb binary rather than the system's as this might happen when running under the root user.

Test Plan
=========

CI to ensure nothing is broken and

```
(nix:nix-shell-env) [javierhonduco@fedora lightswitch]$ nix build .#container
(nix:nix-shell-env) [javierhonduco@fedora lightswitch]$ docker load < result
(nix:nix-shell-env) [javierhonduco@fedora lightswitch]$ docker run -it --privileged --pid host -v /sys/:/sys/ lightswitch:xq7qmc7br6nxn5gd5064z4mns96q4kjf
```