### PR TITLE
Ignore process entries in the munmap tracer

### DIFF
--- a/src/bpf/tracers.bpf.c
+++ b/src/bpf/tracers.bpf.c
@@ -67,8 +67,14 @@ int tracer_enter_munmap(struct munmap_entry_args *args) {
 
     // We might not know about some mappings, but also we definitely don't want to notify
     // of non-executable mappings being unmapped.
-    if (find_mapping(per_process_id, start_address) == NULL){
+    mapping_t *mapping = find_mapping(per_process_id, start_address);
+    if (mapping == NULL){
         return 0;
+    }
+
+    // Ensure we didn't get a process entry.
+    if (start_address < mapping->begin || start_address >= mapping->end) {
+      return 0;
     }
 
     mmap_data_key_t key = {


### PR DESCRIPTION
Otherwise we send events for munmap to userspace about memory mappings that the BPF side doesn't know about, which mostly account for non-executable mappings.

Test Plan
=========

Ran some test workloads without issues but right now the unmapping is not taken into account.