### PR TITLE
unwinder: Fix assumption on thread's initial registers

### DIFF
--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -78,7 +78,7 @@ struct unwinder_stats_t {
   u64 error_unsupported_cfa_register;
   u64 error_catchall;
   u64 error_should_never_happen;
-  u64 error_pc_not_covered;
+  u64 error_bp_should_be_zero_for_bottom_frame;
   u64 error_mapping_not_found;
   u64 error_mapping_does_not_contain_pc;
   u64 error_chunk_not_found;

--- a/src/bpf/profiler_bindings.rs
+++ b/src/bpf/profiler_bindings.rs
@@ -50,7 +50,8 @@ impl Add for unwinder_stats_t {
             error_catchall: self.error_catchall + other.error_catchall,
             error_should_never_happen: self.error_should_never_happen
                 + other.error_should_never_happen,
-            error_pc_not_covered: self.error_pc_not_covered + other.error_pc_not_covered,
+            error_bp_should_be_zero_for_bottom_frame: self.error_bp_should_be_zero_for_bottom_frame
+                + other.error_bp_should_be_zero_for_bottom_frame,
             error_binary_search_exausted_iterations: self.error_binary_search_exausted_iterations
                 + other.error_binary_search_exausted_iterations,
             error_chunk_not_found: self.error_chunk_not_found + other.error_chunk_not_found,

--- a/src/bpf/shared_maps.h
+++ b/src/bpf/shared_maps.h
@@ -37,7 +37,7 @@ DEFINE_COUNTER(error_unsupported_frame_pointer_action);
 DEFINE_COUNTER(error_unsupported_cfa_register);
 DEFINE_COUNTER(error_catchall);
 DEFINE_COUNTER(error_should_never_happen);
-DEFINE_COUNTER(error_pc_not_covered);
+DEFINE_COUNTER(error_bp_should_be_zero_for_bottom_frame);
 DEFINE_COUNTER(error_mapping_not_found);
 DEFINE_COUNTER(error_mapping_does_not_contain_pc);
 DEFINE_COUNTER(error_chunk_not_found);


### PR DESCRIPTION
The x86_64 ABI mandates that the bottom frame of processes must have their frame pointer (rbp) set to zero. We check for this when we detect and end of stacktrace condition, which is correcto for processes but it's not for threads as their initial frame pointer value is not specified.

Test Plan
=========

Ran for a while without issues. Unwinding Node.js applications cause the log to show up, this needs more investigation, but in general we should always use frame pointers to unwind Node. We will revisit this once we add proper support for this runtime.