### PR TITLE
Improve main executable detection

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -47,7 +47,7 @@ impl Collector {
                     load_offset: v.load_offset,
                     load_vaddr: v.load_vaddr,
                     is_dyn: v.is_dyn,
-                    main_bin: v.main_bin,
+                    main_exec: v.main_exec,
                 },
             );
         }


### PR DESCRIPTION
The logic here is a bit flimsy and should be reworked, but let's at least mark first executables as the "main" ones.

More context in the comment but overall this is not always correct, in particular Rust + static musl is broken due how the loader operates for that case.

We should understand the kernel and loader's logic in detail and fully replicate it here.

Test Plan
=========

Ran locally for several minutes without issues. The profilers looked good (see PR) and 0 unexpected errors were emitted.