### PR TITLE
Introduce custom executable id

### DIFF
--- a/src/bpf/profiler.bpf.c
+++ b/src/bpf/profiler.bpf.c
@@ -52,7 +52,7 @@ struct {
 struct {
   __uint(type, BPF_MAP_TYPE_HASH);
   __uint(max_entries, 5 * 1000);
-  __type(key, u32);
+  __type(key, u64);
   __type(value, unwind_info_chunks_t);
 } unwind_info_chunks SEC(".maps");
 
@@ -116,9 +116,9 @@ static __always_inline u64 find_offset_for_pc(stack_unwind_table_t *table, u64 p
 // address.
 static __always_inline chunk_info_t*
 find_chunk(mapping_t *mapping, u64 object_relative_pc) {
-  u32 executable_id = mapping->executable_id;
+  u64 executable_id = mapping->executable_id;
 
-  LOG("~about to check chunks, executable_id=%d", executable_id);
+  LOG("~about to check chunks, executable_id=%lld", executable_id);
   // Find the chunk where this unwind table lives.
   // Each chunk maps to exactly one shard.
   unwind_info_chunks_t *chunks =

--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -125,11 +125,11 @@ typedef struct {
 
 // Represents an executable mapping.
 typedef struct {
-  u32 executable_id;
-  u32 type;
+  u64 executable_id;
   u64 load_address;
   u64 begin;
   u64 end;
+  u32 type;
 } mapping_t;
 
 // Key for the longest prefix matching. This is defined

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tracing::{debug, span, Level};
 
-use crate::object::BuildId;
+use crate::object::ExecutableId;
 use crate::profile::symbolize_profile;
 use crate::profiler::ObjectFileInfo;
 use crate::profiler::ProcessInfo;
@@ -12,7 +12,7 @@ use crate::profiler::SymbolizedAggregatedProfile;
 pub struct Collector {
     profiles: Vec<RawAggregatedProfile>,
     procs: HashMap<i32, ProcessInfo>,
-    objs: HashMap<BuildId, ObjectFileInfo>,
+    objs: HashMap<ExecutableId, ObjectFileInfo>,
 }
 
 type ThreadSafeCollector = Arc<Mutex<Collector>>;
@@ -30,7 +30,7 @@ impl Collector {
         &mut self,
         profile: RawAggregatedProfile,
         procs: &HashMap<i32, ProcessInfo>,
-        objs: &HashMap<BuildId, ObjectFileInfo>,
+        objs: &HashMap<ExecutableId, ObjectFileInfo>,
     ) {
         self.profiles.push(profile);
 
@@ -40,7 +40,7 @@ impl Collector {
 
         for (k, v) in objs {
             self.objs.insert(
-                k.clone(),
+                *k,
                 ObjectFileInfo {
                     file: std::fs::File::open(v.path.clone()).unwrap(),
                     path: v.path.clone(),

--- a/src/util.rs
+++ b/src/util.rs
@@ -121,23 +121,30 @@ mod tests {
             ..Default::default()
         };
 
-        let map =
-            MapHandle::create(MapType::LpmTrie, Some("lpm_test_map"), 16, 32, 1024, &opts).unwrap();
+        let map = MapHandle::create(
+            MapType::LpmTrie,
+            Some("lpm_test_map"),
+            std::mem::size_of::<exec_mappings_key>() as u32,
+            std::mem::size_of::<mapping_t>() as u32,
+            1024,
+            &opts,
+        )
+        .unwrap();
 
         let mapping1 = mapping_t {
             executable_id: 1111,
-            type_: 1,
             load_address: 1111,
             begin: 0x7f7428ea8000,
             end: 0x7f7428f50000,
+            type_: 1,
         };
 
         let mapping2 = mapping_t {
             executable_id: 2222,
-            type_: 2,
             load_address: 2222,
             begin: 0x7f7428f85000,
             end: 0x7f74290e5000,
+            type_: 2,
         };
 
         assert!(mapping1.begin < mapping1.end);


### PR DESCRIPTION
Before this commit the unique identifier for an executable file or object file was the build id. As the GNU's build ID might not be present, we fall back to the sha256 hash of the .text section. This works fine but takes quite a bit of space as we refer to it in every mapping.

By using a 64 bit id derived from the first 8 bytes of the sha256 hash of the code, we can save a good amount of memory, make comparisons and hashings of these IDs faster, and helps simplify the code. For example, there's no need for a separate ID in the native unwind state. There might be a bit more CPU and IO needed to get the hash, but this might be something we can cache in the future.

This is also useful for future profile formats that require unique 64 bit IDs for object files.

This commit also fixes other minor things, such as using the lower hexadecimal representation.

Test Plan
=========

Lots of manual tests, everything seems good.