### PR TITLE
Add `Frame` structure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -223,6 +223,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .clone()
                 .into_iter()
                 .rev()
+                .map(|e| e.to_string())
                 .collect::<Vec<String>>();
             let ustack = ustack.join(";");
             let kstack = sample


### PR DESCRIPTION
Add `Frame` structure and use it in the symbolized stack trace. This new structure stores the address, function name, and whether the function is inlined or not. Before that, all this information might have been encoded as a string, which wasn't ideal as in many cases we might want to do something with these fields. For example, some formats, such as Google's pprof might require the address and function name (if the profile is symbolized).

This is also very useful for debugging as having the address readily available can be important while troubleshooting issues.

Note that right now the user stack addresses are relative to the object file, while the kernel addresses are absolute. This might be something that changes in the future, if we do kernel symbolization in the backend, for example.

Test Plan
=========

Current tests + got some profiles that looked good.