### PR TITLE
Allow eBPF map sizes and general buffer size for profiler to be changed via CLI options

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -127,7 +127,7 @@ impl AggregatorCollector {
     }
 }
 
-/// Aggregagates the samples in memory, which might be acceptable when profiling for short amounts of time.
+/// Aggregates the samples in memory, which might be acceptable when profiling for short amounts of time.
 impl Collector for AggregatorCollector {
     fn collect(
         &mut self,

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,11 +81,7 @@ fn value_is_power_of_two(s: &str) -> Result<usize, String> {
 fn is_power_of_two(v: usize) -> bool {
     // NOTE: Neither 0 nor 1 are a power of 2 (ignoring 2^0 for this use case),
     //       so rule them out
-    if (v != 0) && (v != 1) && ((v & (v - 1)) == 0) {
-        true
-    } else {
-        false
-    }
+    (v != 0) && (v != 1) && ((v & (v - 1)) == 0)
 }
 
 /// Given a non-prime unsigned int, return the prime number that precedes it

--- a/src/main.rs
+++ b/src/main.rs
@@ -458,7 +458,7 @@ mod tests {
 
     #[rstest]
     fn should_be_powers_of_two() {
-        let mut test_uint_strings: Vec<String> = vec![];
+        let mut test_uint_strings = vec![];
         for shift in 1..63 {
             let val: usize = 2 << shift;
             let val_str = val.to_string();
@@ -486,7 +486,7 @@ mod tests {
             let usize_int: usize = between.sample(&mut rng);
             let usize_int_string = usize_int.to_string();
             if test_uint_stringset.contains(&usize_int_string) {
-                println!("{}", usize_int_string);
+                // We know this is a power of 2, already tested separately, skip
                 continue;
             }
             let result = value_is_power_of_two(usize_int_string.as_str());

--- a/src/main.rs
+++ b/src/main.rs
@@ -558,7 +558,7 @@ mod tests {
     #[rstest]
     fn args_should_not_be_powers_of_two(all_but_power_of_two_strings: Vec<String>) {
         for non_p2_string in all_but_power_of_two_strings {
-            let result = value_is_power_of_two(&non_p2_string.as_str());
+            let result = value_is_power_of_two(non_p2_string.as_str());
             assert!(result.is_err());
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,17 +257,18 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     }));
 
-    let profiler_config = ProfilerConfig(
-        args.bpf_logging,
-        args.duration,
-        args.sample_freq,
-        args.mapsize_info,
-        args.mapsize_stacks,
-        args.mapsize_aggregated_stacks,
-        args.mapsize_unwind_info_chunks,
-        args.mapsize_unwind_tables,
-        args.mapsize_rate_limits,
-    );
+    let profiler_config = ProfilerConfig {
+        libbpf_debug: args.libbpf_logs,
+        bpf_logging: args.bpf_logging,
+        duration: args.duration,
+        sample_freq: args.sample_freq,
+        mapsize_info: args.mapsize_info,
+        mapsize_stacks: args.mapsize_stacks,
+        mapsize_aggregated_stacks: args.mapsize_aggregated_stacks,
+        mapsize_unwind_info_chunks: args.mapsize_unwind_info_chunks,
+        mapsize_unwind_tables: args.mapsize_unwind_tables,
+        mapsize_rate_limits: args.mapsize_rate_limits,
+    };
     let mut p: Profiler<'_> = Profiler::new(profiler_config);
     p.profile_pids(args.pids);
     p.run(collector.clone());

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -163,7 +163,7 @@ pub struct Profiler<'bpf> {
     duration: Duration,
     // Per-CPU Sampling Frequency of this profile in Hz
     sample_freq: u16,
-    // Size of each perf buffer, in include_bytes!
+    // Size of each perf buffer, in bytes
     perf_buffer_bytes: usize,
     session_duration: Duration,
 }
@@ -297,11 +297,27 @@ pub struct ProfilerConfig {
     pub mapsize_rate_limits: u32,
 }
 
-// impl Default for Profiler<'_> {
-//     fn default() -> Self {
-//         Self::new(false, false, Duration::MAX, 19)
-//     }
-// }
+// Note that we zero out most of the fields in the default ProfilerConfig here,
+// as we're normally going to pass in the defaults from Clap, and we don't want
+// to be in the business of keeping the default values defined in Clap in sync
+// with the defaults defined here.
+impl Default for ProfilerConfig {
+    fn default() -> Self {
+        Self {
+            libbpf_debug: false,
+            bpf_logging: false,
+            duration: Duration::MAX,
+            sample_freq: 0,
+            perf_buffer_bytes: 0,
+            mapsize_info: false,
+            mapsize_stacks: 0,
+            mapsize_aggregated_stacks: 0,
+            mapsize_unwind_info_chunks: 0,
+            mapsize_unwind_tables: 0,
+            mapsize_rate_limits: 0,
+        }
+    }
+}
 
 impl Profiler<'_> {
     pub fn new(profiler_config: ProfilerConfig) -> Self {

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -300,24 +300,24 @@ pub struct ProfilerConfig {
     pub mapsize_rate_limits: u32,
 }
 
-// Note that we zero out most of the fields in the default ProfilerConfig here,
-// as we're normally going to pass in the defaults from Clap, and we don't want
+// Note that we normally pass in the defaults from Clap, and we don't want
 // to be in the business of keeping the default values defined in Clap in sync
-// with the defaults defined here.
+// with the defaults defined here.  So these are some defaults that will
+// almost always be overridden.
 impl Default for ProfilerConfig {
     fn default() -> Self {
         Self {
             libbpf_debug: false,
             bpf_logging: false,
             duration: Duration::MAX,
-            sample_freq: 0,
-            perf_buffer_bytes: 0,
+            sample_freq: 19,
+            perf_buffer_bytes: 512 * 1024,
             mapsize_info: false,
-            mapsize_stacks: 0,
-            mapsize_aggregated_stacks: 0,
-            mapsize_unwind_info_chunks: 0,
-            mapsize_unwind_tables: 0,
-            mapsize_rate_limits: 0,
+            mapsize_stacks: 100000,
+            mapsize_aggregated_stacks: 10000,
+            mapsize_unwind_info_chunks: 5000,
+            mapsize_unwind_tables: 65,
+            mapsize_rate_limits: 5000,
         }
     }
 }
@@ -501,8 +501,8 @@ impl Profiler<'_> {
             })
             .lost_cb(Self::handle_lost_events)
             .build()
-            // TODO: Instead of unwrap, consume and emit any error - usually
-            // about buffer bytes not being a power of 2
+            // TODO: Instead of unwrap, consume and emit any error, with
+            // .expect() perhaps?
             .unwrap();
 
         let _poll_thread = thread::spawn(move || loop {
@@ -525,8 +525,8 @@ impl Profiler<'_> {
                     warn!("lost {} events from the tracers", lost_count);
                 })
                 .build()
-                // TODO: Instead of unwrap, consume and emit any error - usually
-                // about buffer bytes not being a power of 2
+                // TODO: Instead of unwrap, consume and emit any error, with
+                // .expect() perhaps?
                 .unwrap();
 
         let _tracers_poll_thread = thread::spawn(move || loop {

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -346,25 +346,30 @@ impl Profiler<'_> {
         // mapsize modifications can only be made before the maps are actually loaded
         // Initialize map sizes with defaults or modifications
         open_skel
-            .maps()
+            .maps_mut()
             .stacks()
-            .set_max_entries(profiler_config.mapsize_stacks);
+            .set_max_entries(profiler_config.mapsize_stacks)
+            .expect("Unable to set stacks map max_entries");
         open_skel
-            .maps()
+            .maps_mut()
             .aggregated_stacks()
-            .set_max_entries(profiler_config.mapsize_aggregated_stacks);
+            .set_max_entries(profiler_config.mapsize_aggregated_stacks)
+            .expect("Unable to set aggregated_stacks map max_entries");
         open_skel
-            .maps()
+            .maps_mut()
             .unwind_info_chunks()
-            .set_max_entries(profiler_config.mapsize_unwind_info_chunks);
+            .set_max_entries(profiler_config.mapsize_unwind_info_chunks)
+            .expect("Unable to set unwind_info_chunks map max_entries");
         open_skel
-            .maps()
+            .maps_mut()
             .unwind_tables()
-            .set_max_entries(profiler_config.mapsize_unwind_tables);
+            .set_max_entries(profiler_config.mapsize_unwind_tables)
+            .expect("Unable to set unwind_tables map max_entries");
         open_skel
-            .maps()
+            .maps_mut()
             .rate_limits()
-            .set_max_entries(profiler_config.mapsize_rate_limits);
+            .set_max_entries(profiler_config.mapsize_rate_limits)
+            .expect("Unable to set rate_limits map max_entries");
         open_skel
             .rodata_mut()
             .lightswitch_config

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -101,17 +101,11 @@ fn test_integration() {
     ));
 
     let profiler_config = ProfilerConfig {
-        libbpf_debug: bpf_test_debug,     // changed from default
-        bpf_logging: bpf_test_debug,      // changed from default
-        duration: Duration::from_secs(5), // changed from default
-        sample_freq: 999,                 // changed from default
-        perf_buffer_bytes: 512 * 1024,
-        mapsize_info: false,
-        mapsize_stacks: 100000,
-        mapsize_aggregated_stacks: 10000,
-        mapsize_unwind_info_chunks: 5000,
-        mapsize_unwind_tables: 65,
-        mapsize_rate_limits: 5000,
+        libbpf_debug: bpf_test_debug,
+        bpf_logging: bpf_test_debug,
+        duration: Duration::from_secs(5),
+        sample_freq: 999,
+        ..Default::default()
     };
     let (_stop_signal_send, stop_signal_receive) = bounded(1);
     let mut p = Profiler::new(profiler_config, stop_signal_receive);


### PR DESCRIPTION
This PR adds several CLI options to set defaults for and allow modifying the size of most eBPF maps and the perf buffer for the profiler:

* `--mapsize-info` prints the eBPF map sizes after they've been created
* `--mapsize-stacks` to adjust max number of individual stacks to capture before they are aggregated
* `--mapsize-aggregated-stacks` to adjust the max number of unique stacks to be stored after aggregation from the stacks map
* `--mapsize-unwind-info-chunks` to adjust the max number of chunks allowed to be in a single shard
* `--mapsize-unwind-tables` to adjust the max number of shards allowed
* `--mapsize-rate-limits` to adjust when to impose rate limits on incoming profiling data
* `--perf-buffer-bytes` to adjust the size of each profiler perf buffer

Also added a config validator for `--perf-buffer-bytes`, as the value must be a power of 2.

Added tests for the validator function.