### PR TITLE
Use `crossbeam_channel` and stop profiling on control+c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "ctrlc"
+version = "3.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "672465ae37dc1bc6380a6547a8883d5dd397b0f1faaad4f265726cc7042a5345"
+dependencies = [
+ "nix 0.28.0",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1137,8 @@ dependencies = [
  "blazesym",
  "chrono",
  "clap",
+ "crossbeam-channel",
+ "ctrlc",
  "data-encoding",
  "errno",
  "gimli 0.31.0",
@@ -1155,6 +1167,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-subscriber",
+ "v",
 ]
 
 [[package]]
@@ -2568,6 +2581,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "v"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bf1cdfefda84a01134d6a5a9815fbf66c8df618f03b8c2296e6d06041a2e75"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ nix = { version = "0.29.0", features = ["user"] }
 prost = "0.12" # Needed to encode protocol buffers to bytes.
 reqwest = { version = "0.12", features = ["blocking"] }
 lightswitch-proto = { path = "./lightswitch-proto"}
+ctrlc = "3.4.4"
+v = "0.1.0"
+crossbeam-channel = "0.5.13"
 
 [dev-dependencies]
 assert_cmd = { version = "2.0.14" }


### PR DESCRIPTION
The `crossbeam_channel` crate offers a couple of nice features that the standard library producer/comsumer channel doesn't have, including a `select!` macro that lets us poll from the first available channel when we are polling from several channels. This commit reworks this logic to unify everything using this macro, resulting in potential fewer waits in the worst case scenario and cleaner logic.

This work started to add support for SIGINT aka control+c handling, which is included in this commit. Once the signal is received, profiling will stop and the profile will be dealt with as soon as the channels are polled again.

Test Plan
=========

Interrupted profiling with control+C without any issues, made sure it works for short and long durations to verify there are no regressions.