### PR TITLE
Add statistics for encounters of vDSO or JIT

### DIFF
--- a/src/bpf/profiler.bpf.c
+++ b/src/bpf/profiler.bpf.c
@@ -338,11 +338,13 @@ int dwarf_unwind(struct bpf_perf_event_data *ctx) {
 
     if (mapping->type == 1) {
       LOG("JIT section, stopping");
+      bump_unwind_jit_encountered();
       return 1;
     }
 
     if (mapping->type == 2) {
       LOG("vDSO section, stopping");
+      bump_unwind_vdso_encountered();
       return 1;
     }
 

--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -85,6 +85,8 @@ struct unwinder_stats_t {
   u64 error_binary_search_exausted_iterations;
   u64 error_sending_new_process_event;
   u64 error_cfa_offset_did_not_fit;
+  u64 vdso_encountered;
+  u64 jit_encountered;
 };
 
 const volatile struct lightswitch_config_t lightswitch_config = {.verbose_logging =

--- a/src/bpf/profiler_bindings.rs
+++ b/src/bpf/profiler_bindings.rs
@@ -62,6 +62,8 @@ impl Add for unwinder_stats_t {
                 + other.error_sending_new_process_event,
             error_cfa_offset_did_not_fit: self.error_cfa_offset_did_not_fit
                 + other.error_cfa_offset_did_not_fit,
+            vdso_encountered: self.vdso_encountered + other.vdso_encountered,
+            jit_encountered: self.jit_encountered + other.jit_encountered,
         }
     }
 }

--- a/src/bpf/shared_maps.h
+++ b/src/bpf/shared_maps.h
@@ -44,5 +44,7 @@ DEFINE_COUNTER(error_chunk_not_found);
 DEFINE_COUNTER(error_binary_search_exausted_iterations);
 DEFINE_COUNTER(error_sending_new_process_event);
 DEFINE_COUNTER(error_cfa_offset_did_not_fit);
+DEFINE_COUNTER(vdso_encountered);
+DEFINE_COUNTER(jit_encountered);
 
 #endif

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -730,7 +730,6 @@ impl Profiler<'_> {
     pub fn clear_maps(&mut self) {
         let _span = span!(Level::DEBUG, "clear_maps").entered();
 
-        self.clear_stats_map();
         self.clear_map("stacks");
         self.clear_map("aggregated_stacks");
         self.clear_map("rate_limits");
@@ -1043,7 +1042,6 @@ impl Profiler<'_> {
                     // TODO: Avoid resetting the state too often.
                     self.native_unwind_state = NativeUnwindState::default();
 
-                    self.clear_stats_map();
                     // With the current implementation of the unwind information reset, we might
                     // wipe stacks that we would like to read from userspace. We could fix this by
                     // resetting after a profiling session is done.


### PR DESCRIPTION
This PR adds counters for two types of frames that may be encountered during unwinding that we don't currently _handle_, but want to know if we've encountered them on particular workloads:

* vDSO
* JIT

We also stop clearing the statistics records on each collection interval, so that we get a good overall set of statistics for run lifetimes of the agent process.