### PR TITLE
Fix race while copying `ObjectFileInfo`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,6 +1288,7 @@ dependencies = [
  "ring",
  "rstest",
  "tempdir",
+ "tempfile",
  "thiserror",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ rstest = "0.21.0"
 tempdir = "0.3.7"
 rand = "0.8.5"
 criterion = "0.5.1"
+tempfile = "3.12.0"
 
 [build-dependencies]
 bindgen = "0.69.4"

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -141,18 +141,8 @@ impl Collector for AggregatorCollector {
             self.procs.insert(*k, v.clone());
         }
 
-        for (k, v) in objs {
-            self.objs.insert(
-                *k,
-                ObjectFileInfo {
-                    file: std::fs::File::open(v.path.clone()).unwrap(),
-                    path: v.path.clone(),
-                    load_offset: v.load_offset,
-                    load_vaddr: v.load_vaddr,
-                    is_dyn: v.is_dyn,
-                    references: 0, // The reference count does not matter here.
-                },
-            );
+        for (object_id, object_file_info) in objs {
+            self.objs.insert(*object_id, object_file_info.clone());
         }
     }
 


### PR DESCRIPTION
There was a fundamental race that could (and did!) happen while copying / cloning `ObjectFileInfo`, as we tried to open the file using the original file path, if the file had been removed, re-opening would fail. This commit leverages procfs to reopen a file that might already have been deleted, as long as there are some file descriptors pointing to it, as the kernel won't effectively remove the file until its reference count reaches zero.

Test Plan
=========

Added test to exercise this code path. Also run the profiler while compiling the Linux kernel as this as this triggered the crash in the past.