### PR TITLE
Point to our own repo for kernel images

### DIFF
--- a/vm.nix
+++ b/vm.nix
@@ -4,7 +4,7 @@ let
   kernel_5_15 = pkgs.stdenv.mkDerivation {
     name = "download-kernel-5.15";
     src = pkgs.fetchurl {
-      url = "https://github.com/danobi/vmtest/releases/download/test_assets/bzImage-v5.15-fedora38";
+      url = "https://github.com/javierhonduco/lightswitch-kernels/raw/cfb94e9/bzImage-v5.15-fedora38";
       hash = "sha256-nq8W72vuNKCgO1OS6aJtAfg7AjHavRZ7WAkP7X6V610=";
     };
     dontUnpack = true;
@@ -17,7 +17,7 @@ let
   kernel_6_0 = pkgs.stdenv.mkDerivation {
     name = "download-kernel-6.0";
     src = pkgs.fetchurl {
-      url = "https://github.com/danobi/vmtest/releases/download/test_assets/bzImage-v6.0-fedora38";
+      url = "https://github.com/javierhonduco/lightswitch-kernels/raw/cfb94e9/bzImage-v6.0-fedora38";
       hash = "sha256-ZBBQ0yVUn+Isd2b+a32oMEbNo8T1v46P3rEtZ+1j9Ic=";
     };
     dontUnpack = true;
@@ -30,7 +30,7 @@ let
   kernel_6_2 = pkgs.stdenv.mkDerivation {
     name = "download-kernel-6.2";
     src = pkgs.fetchurl {
-      url = "https://github.com/danobi/vmtest/releases/download/test_assets/bzImage-v6.2-fedora38";
+      url = "https://github.com/javierhonduco/lightswitch-kernels/raw/cfb94e9/bzImage-v6.2-fedora38";
       hash = "sha256-YO2HEIWTuEEJts9JrW3V7UVR7t4J3+8On+tjdELa2m8=";
     };
     dontUnpack = true;
@@ -43,7 +43,7 @@ let
   kernel_6_6 = pkgs.stdenv.mkDerivation {
     name = "download-kernel-6.6";
     src = pkgs.fetchurl {
-      url = "https://github.com/danobi/vmtest/releases/download/test_assets/bzImage-v6.6-fedora38";
+      url = "https://github.com/javierhonduco/lightswitch-kernels/raw/cfb94e9/bzImage-v6.6-fedora38";
       hash = "sha256-6Fu16SPBITP0sI3lapkckZna6GKBn2hID038itt82jA=";
     };
     dontUnpack = true;
@@ -56,7 +56,7 @@ let
   kernel_6_8_7 = pkgs.stdenv.mkDerivation {
     name = "download-kernel-6.8.7";
     src = pkgs.fetchurl {
-      url = "https://github.com/javierhonduco/lightswitch-kernels/raw/c0af7a3/bzImage_v6.8.7";
+      url = "https://github.com/javierhonduco/lightswitch-kernels/raw/cfb94e9/bzImage_v6.8.7";
       hash = "sha256-fZwGajRi9+otzokRxoss99aH9PLRuyl2UfJ5Echehdo=";
     };
     dontUnpack = true;
@@ -69,7 +69,7 @@ let
   kernel_6_9_rc5 = pkgs.stdenv.mkDerivation {
     name = "download-kernel-6.9-rc5";
     src = pkgs.fetchurl {
-      url = "https://github.com/javierhonduco/lightswitch-kernels/raw/c0af7a3/bzImage_v6.9-rc5";
+      url = "https://github.com/javierhonduco/lightswitch-kernels/raw/cfb94e9/bzImage_v6.9-rc5";
       hash = "sha256-EA+nJ1M0/6QFPVA+fYkvXDhBcsmTnALpGr+tCJZsVyw=";
     };
     dontUnpack = true;


### PR DESCRIPTION
As images in danobi's releases might be updated anytime triggering build errors, we prefer to ossify this and fully control updates to avoid a bad devex.

Test Plan
=========

ci :)