### PR TITLE
Rework native unwind information storage and retrieval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,7 +1151,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
- "libbpf-rs",
+ "libbpf-rs 0.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap2 0.5.10",
  "regex",
  "semver",
@@ -1170,6 +1170,17 @@ dependencies = [
  "libbpf-sys",
  "libc",
  "strum_macros",
+ "vsprintf",
+]
+
+[[package]]
+name = "libbpf-rs"
+version = "0.23.3"
+source = "git+https://github.com/libbpf/libbpf-rs?rev=4ebf2ac7cd509e9442aff9b9f92164f252adf2a3#4ebf2ac7cd509e9442aff9b9f92164f252adf2a3"
+dependencies = [
+ "bitflags",
+ "libbpf-sys",
+ "libc",
  "vsprintf",
 ]
 
@@ -1219,9 +1230,11 @@ dependencies = [
  "glob",
  "inferno",
  "insta",
+ "itertools 0.13.0",
  "lazy_static",
  "libbpf-cargo",
- "libbpf-rs",
+ "libbpf-rs 0.23.3 (git+https://github.com/libbpf/libbpf-rs?rev=4ebf2ac7cd509e9442aff9b9f92164f252adf2a3)",
+ "libbpf-sys",
  "libc",
  "lightswitch-capabilities",
  "lightswitch-proto",
@@ -1255,7 +1268,7 @@ dependencies = [
  "errno",
  "glob",
  "libbpf-cargo",
- "libbpf-rs",
+ "libbpf-rs 0.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
  "nix",
  "perf-event-open-sys",
@@ -1778,7 +1791,7 @@ checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -1798,7 +1811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.79",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ object = "0.36.4"
 memmap2 = "0.9.5"
 lazy_static = "1.5.0"
 anyhow = "1.0.89"
-thiserror = "1.0.64"
-libbpf-rs = { version = "0.23.3", features = ["static"] }
+thiserror = "1.0.63"
+# TODO: Move to a release.
+libbpf-rs = { git = "https://github.com/libbpf/libbpf-rs", rev="4ebf2ac7cd509e9442aff9b9f92164f252adf2a3", features = ["static"] }
 perf-event-open-sys = "4.0.0"
 libc = "0.2.159"
 errno = "0.3.9"
@@ -39,6 +40,8 @@ lightswitch-capabilities = {path = "./lightswitch-capabilities"}
 ctrlc = "3.4.5"
 v = "0.1.0"
 crossbeam-channel = "0.5.13"
+libbpf-sys = "1.4.3"
+itertools = "0.13.0"
 
 [dev-dependencies]
 assert_cmd = { version = "2.0.16" }

--- a/src/bpf/profiler_bindings.rs
+++ b/src/bpf/profiler_bindings.rs
@@ -12,10 +12,11 @@ include!(concat!(env!("OUT_DIR"), "/profiler_bindings.rs"));
 unsafe impl Plain for stack_count_key_t {}
 unsafe impl Plain for native_stack_t {}
 unsafe impl Plain for Event {}
-unsafe impl Plain for unwind_info_chunks_t {}
 unsafe impl Plain for unwinder_stats_t {}
 unsafe impl Plain for exec_mappings_key {}
 unsafe impl Plain for mapping_t {}
+unsafe impl Plain for page_key_t {}
+unsafe impl Plain for page_value_t {}
 
 impl exec_mappings_key {
     pub fn new(pid: u32, address: u64, prefix_len: u32) -> Self {
@@ -75,7 +76,9 @@ impl Add for unwinder_stats_t {
 impl From<&CompactUnwindRow> for stack_unwind_row_t {
     fn from(row: &CompactUnwindRow) -> Self {
         stack_unwind_row_t {
-            pc: row.pc,
+            // The 64 bit casting is necessary due to a parsing bug in bindgen:
+            // https://github.com/rust-lang/rust-bindgen/issues/923#issuecomment-2385554573
+            pc_low: (row.pc & LOW_PC_MASK as u64) as u16,
             cfa_offset: row.cfa_offset,
             cfa_type: row.cfa_type,
             rbp_type: row.rbp_type,

--- a/src/bpf/shared_maps.h
+++ b/src/bpf/shared_maps.h
@@ -8,7 +8,7 @@ struct {
   __type(key, struct exec_mappings_key);
   __type(value, mapping_t);
   __uint(map_flags, BPF_F_NO_PREALLOC);
-  __uint(max_entries, MAX_PROCESSES * 200);
+  __uint(max_entries, MAX_MAPPINGS);
 } exec_mappings SEC(".maps");
 
 struct {

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,6 +323,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         mapsize_unwind_tables: args.mapsize_unwind_tables,
         mapsize_rate_limits: args.mapsize_rate_limits,
         exclude_self: args.exclude_self,
+        ..Default::default()
     };
 
     let (stop_signal_sender, stop_signal_receive) = bounded(1);

--- a/src/unwind_info.rs
+++ b/src/unwind_info.rs
@@ -444,3 +444,138 @@ pub fn in_memory_unwind_info(path: &str) -> anyhow::Result<Vec<CompactUnwindRow>
 
     Ok(unwind_info)
 }
+
+#[derive(Debug, PartialEq)]
+pub struct Page {
+    pub address: u64,
+    pub index: u32,
+    pub len: u32,
+}
+
+/// Splits a slice of unwind info in 16 bit pages.
+///
+/// Splits a slice of continguous compact unwind info into pages of a fixed
+/// size. Right now this size is hardcoded to 16 bits, to be able to find the
+/// unwind info in a given page in 16 iterations, and represent the program
+/// counters with 32 bits (32 bits for PC + 16 bits for page offset = 48 bits,
+/// which is enough as the upper 16 bits are unused).
+pub fn to_pages(unwind_info: &[CompactUnwindRow]) -> Vec<Page> {
+    let page_size_bits = 16;
+    let low_bits_mask = u64::pow(2, page_size_bits) - 1;
+    let high_bits_mask = u64::MAX ^ low_bits_mask;
+
+    let mut pages = vec![];
+    let mut curr_page_id = None;
+    let mut prev_index = 0;
+
+    for (i, row) in unwind_info.iter().enumerate() {
+        let pc = row.pc;
+        let pc_high = pc & high_bits_mask;
+        match curr_page_id {
+            None => {
+                // First one we see.
+                curr_page_id = Some(pc_high);
+            }
+            Some(current_page_id) => {
+                if current_page_id != pc_high {
+                    pages.push(Page {
+                        address: current_page_id,
+                        index: prev_index.try_into().unwrap(),
+                        len: i.try_into().unwrap(),
+                    });
+                    prev_index = i;
+                    curr_page_id = Some(pc_high);
+                }
+            }
+        }
+    }
+
+    // Add last page.
+    if let Some(id) = curr_page_id {
+        pages.push(Page {
+            address: id,
+            index: prev_index.try_into().unwrap(),
+            len: unwind_info.len().try_into().unwrap(),
+        });
+    }
+
+    pages
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::unwind_info::*;
+
+    #[test]
+    fn test_to_pages() {
+        let unwind_info = vec![];
+        let chunks = to_pages(&unwind_info);
+        assert_eq!(chunks, vec![]);
+
+        let row = CompactUnwindRow::default();
+        let unwind_info = vec![CompactUnwindRow { pc: 0x100, ..row }];
+        let chunks = to_pages(&unwind_info);
+        assert_eq!(
+            chunks,
+            vec![Page {
+                address: 0x0,
+                index: 0,
+                len: 1,
+            }]
+        );
+
+        let unwind_info = vec![
+            CompactUnwindRow { pc: 0xf7527, ..row },
+            CompactUnwindRow { pc: 0xf7530, ..row },
+            CompactUnwindRow { pc: 0xfac00, ..row },
+            CompactUnwindRow { pc: 0xfac68, ..row },
+            CompactUnwindRow {
+                pc: 0x1102f4,
+                ..row
+            },
+            CompactUnwindRow {
+                pc: 0x1103f4,
+                ..row
+            },
+        ];
+        let chunks = to_pages(&unwind_info);
+        assert!(
+            unwind_info.is_sorted_by(|a, b| a.pc <= b.pc),
+            "unwind info is sorted"
+        );
+        assert_eq!(
+            chunks,
+            vec![
+                Page {
+                    address: 983040,
+                    index: 0,
+                    len: 4,
+                },
+                Page {
+                    address: 1114112,
+                    index: 4,
+                    len: 6,
+                },
+            ]
+        );
+
+        // Exhaustively test that we cover every unwind row
+        let page_size_bits = 16;
+        let low_bits_mask = u64::pow(2, page_size_bits) - 1;
+        let high_bits_mask = u64::MAX ^ low_bits_mask;
+        let pages = to_pages(&unwind_info);
+
+        for row in &unwind_info {
+            let pc = row.pc;
+            let pc_high = pc & high_bits_mask;
+            assert_eq!(pc_high, pc_high & 0x0000FFFFFFFF0000); // [ 16 unused bits -- 32 bits for high -- 16 bits for each page ]
+                                                               // Test that we can find it in the pages, linearly, but it's small enough
+            let found = pages.iter().find(|el| el.address == pc_high).unwrap();
+            // Make sure we can find the inner slice
+            let search_here = &unwind_info[(found.index as usize)..(found.len as usize)];
+            let found_row = search_here.iter().find(|el| el.pc == pc).unwrap();
+            // And that the high and low bits were done ok
+            assert_eq!((found_row.pc & low_bits_mask) + pc_high, found_row.pc);
+        }
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,6 @@
-use anyhow::{Context, Error};
 use std::{fs::File, io::Read};
+
+use anyhow::{Context, Error};
 
 #[derive(Debug, PartialEq)]
 pub struct AddressBlockRange {
@@ -82,6 +83,7 @@ mod tests {
     use tempdir::TempDir;
 
     use libbpf_rs::libbpf_sys;
+    use libbpf_rs::MapCore;
     use libbpf_rs::MapFlags;
     use libbpf_rs::MapHandle;
     use libbpf_rs::MapType;


### PR DESCRIPTION
This rather large commit fundamentally modifies how unwind information
is stored and retrieved. Until now we had a BPF hashmap where we stored
a large C array in the values. The keys were used to index said values.
We called each entry a "shard", where unwind information would be
written. The way this worked was that whenever we had unwind information
we wanted to store, we will append it to the current shard and/or
continue appending in a new shard. We effectively treated this as a
contiguous chunk of memory, that operated like a bump allocator.

As the unwind information we wanted to append might not fit in the
shard, we would have to split or chunk said unwind information. In order
to query it, we would search an array chunks with a linear search.

The above offers a good solution to maximising space utilisation, but it
has a bunch of drawbacks, including:

- once there is no storage space left, what to do is a difficult
  tradeoff to make. We were wiping the whole state after a few profiling
rounds, to ensure we would get some samples. This would cause a large
spike in CPU and memory usage, as we would have to re-generate the
unwind info (it could have been cached, but this is not implemented
yet), split it, and update it, issuing BPF map updates that could be
quite large.
- we would allocate all the memory up front, as the BPF maps configuration
 is set in stone once the programs are loaded. We were using around 400
MB which might be unsuitable for some environments. Dynamically probing
the amount of free memory could be possible but it's brittle.
- due to the above, reliability can be affected. For example, memory
  allocations can fail in high memory pressure situations.
- removing the unwind information for an object file is not possible.
  Implementing this would be implementing a full-blown memory allocator
on top of BPF maps, with all the issues this has, including having to
deal with fragmentation, etc.

Lastly, we perform a fixed number of binary search iterations to find
the unwind row for a given PC. This was limiting the maximum chunk size,
which we could have dealt with by inserting extra chunks and
partitioning the unwind info space, which brings us to...

Unwind information divided in equal chunks or pages, which is this
implementation. The unwind info is split in 16 bit pages, this has a
couple of advantages:
- we can represent the BPF unwind row's PC using a 16 bit number, and
  then address each pages with the higher bits of the program counter.
This has several benefits, the representation is more compact, allowing
for more rows in every cache line, and we don't have to perform
unaligned reads as the size of the structure fits in 8 bytes. Finding
the right page can be done in O(1) if we index the page by
(executable_id, high_page_bits).
- binary searching over each of the pages is guaranteed to not require
  more than 16 steps.

The unwind information is not stored in a unwind info bucket. These are
BPF 'maps of maps' that has a key they have the executable_id, and has a
value they have a BPF array that stores the unwind information rows.

We need different buckets because the verifier requires that for each
'outer' map the 'inner' map must be configured before loading the
program, so we can store up to X elements per object in each bucket.

This will allow us to remove / evict unwind information in a more
granular way, doesn't require us to allocate large amount of locked
memory, as we can allocate BPF arrays on the fly and store them in
'outer' maps, etc.

This commit also changes the following:
- track when the reference count for object files drops to zero and
  evict them from their BPF maps.
- remove process data from BPF maps on program exit.

Test Plan
=========

Many manual runs and CI

<img width="608" alt="image" src="https://github.com/user-attachments/assets/1df4e192-b105-4e37-bfd7-3414c8de46ac">