### PR TITLE
Optionally symbolize profiles

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,13 @@ enum ProfileSender {
     Remote,
 }
 
+#[derive(PartialEq, clap::ValueEnum, Debug, Clone, Default)]
+enum Symbolizer {
+    #[default]
+    Local,
+    None,
+}
+
 #[derive(Parser, Debug)]
 struct Cli {
     /// Specific PIDs to profile
@@ -219,6 +226,8 @@ struct Cli {
     // Exclude myself from profiling
     #[arg(long, help = "Do not profile the profiler (myself)")]
     exclude_self: bool,
+    #[arg(long, default_value_t, value_enum)]
+    symbolizer: Symbolizer,
 }
 
 /// Exit the main thread if any thread panics. We prefer this behaviour because pretty much every
@@ -304,9 +313,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         ProfileSender::LocalDisk => {
             Box::new(AggregatorCollector::new()) as Box<dyn Collector + Send>
         }
-        ProfileSender::Remote => {
-            Box::new(StreamingCollector::new(PPROF_INGEST_URL)) as Box<dyn Collector + Send>
-        }
+        ProfileSender::Remote => Box::new(StreamingCollector::new(
+            args.symbolizer == Symbolizer::Local,
+            PPROF_INGEST_URL,
+        )) as Box<dyn Collector + Send>,
     }));
 
     let profiler_config = ProfilerConfig {
@@ -339,7 +349,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     p.run(collector.clone());
 
     let collector = collector.lock().unwrap();
-    let (raw_profile, procs, objs) = collector.finish();
+    let (mut profile, procs, objs) = collector.finish();
 
     // If we need to send the profile to the backend there's nothing else to do.
     match args.sender {
@@ -350,11 +360,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     // Otherwise let's symbolize the profile and write it to disk.
-    let symbolized_profile = symbolize_profile(&raw_profile, procs, objs);
+    if args.symbolizer == Symbolizer::Local {
+        profile = symbolize_profile(&profile, procs, objs);
+    }
 
     match args.profile_format {
         ProfileFormat::FlameGraph => {
-            let folded = fold_profile(symbolized_profile);
+            let folded = fold_profile(profile);
             let mut options: flamegraph::Options<'_> = flamegraph::Options::default();
             let data = folded.as_bytes();
             let f = File::create(args.profile_name.unwrap_or_else(|| "flame.svg".into())).unwrap();
@@ -369,7 +381,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
         ProfileFormat::Pprof => {
             let mut buffer = Vec::new();
-            let proto = to_pprof(symbolized_profile, procs, objs);
+            let proto = to_pprof(profile, procs, objs);
             proto.validate().unwrap();
             proto.profile().encode(&mut buffer).unwrap();
             let mut pprof_file =
@@ -414,9 +426,9 @@ mod tests {
         cmd.arg("--help");
         cmd.assert().success();
         let actual = String::from_utf8(cmd.unwrap().stdout).unwrap();
-        insta::assert_yaml_snapshot!(actual, @r###"
-        "Usage: lightswitch [OPTIONS]\n\nOptions:\n      --pids <PIDS>\n          Specific PIDs to profile\n\n      --tids <TIDS>\n          Specific TIDs to profile (these can be outside the PIDs selected above)\n\n      --show-unwind-info <PATH_TO_BINARY>\n          Show unwind info for given binary\n\n      --show-info <PATH_TO_BINARY>\n          Show build ID for given binary\n\n  -D, --duration <DURATION>\n          How long this agent will run in seconds\n          \n          [default: 18446744073709551615]\n\n      --libbpf-logs\n          Enable libbpf logs. This includes the BPF verifier output\n\n      --bpf-logging\n          Enable BPF programs logging\n\n      --logging <LOGGING>\n          Set lightswitch's logging level\n          \n          [default: info]\n          [possible values: trace, debug, info, warn, error]\n\n      --sample-freq <SAMPLE_FREQ_IN_HZ>\n          Per-CPU Sampling Frequency in Hz\n          \n          [default: 19]\n\n      --profile-format <PROFILE_FORMAT>\n          Output file for Flame Graph in SVG format\n          \n          [default: flame-graph]\n          [possible values: none, flame-graph, pprof]\n\n      --profile-name <PROFILE_NAME>\n          Name for the generated profile\n\n      --sender <SENDER>\n          Where to write the profile\n          \n          [default: local-disk]\n\n          Possible values:\n          - none:       Discard the profile. Used for kernel tests\n          - local-disk\n          - remote\n\n      --perf-buffer-bytes <PERF_BUFFER_BYTES>\n          Size of each profiler perf buffer, in bytes (must be a power of 2)\n          \n          [default: 524288]\n\n      --mapsize-info\n          Print eBPF map sizes after creation\n\n      --mapsize-stacks <MAPSIZE_STACKS>\n          max number of individual stacks to capture before aggregation\n          \n          [default: 100000]\n\n      --mapsize-aggregated-stacks <MAPSIZE_AGGREGATED_STACKS>\n          Derived from constant MAX_AGGREGATED_STACKS_ENTRIES - max number of unique stacks after aggregation\n          \n          [default: 10000]\n\n      --mapsize-unwind-info-chunks <MAPSIZE_UNWIND_INFO_CHUNKS>\n          max number of chunks allowed inside a shard\n          \n          [default: 5000]\n\n      --mapsize-unwind-tables <MAPSIZE_UNWIND_TABLES>\n          Derived from constant MAX_UNWIND_INFO_SHARDS\n          \n          [default: 65]\n\n      --mapsize-rate-limits <MAPSIZE_RATE_LIMITS>\n          Derived from constant MAX_PROCESSES\n          \n          [default: 5000]\n\n      --exclude-self\n          Do not profile the profiler (myself)\n\n  -h, --help\n          Print help (see a summary with '-h')\n"
-        "###);
+        insta::assert_yaml_snapshot!(actual, @r#"
+        "Usage: lightswitch [OPTIONS]\n\nOptions:\n      --pids <PIDS>\n          Specific PIDs to profile\n\n      --tids <TIDS>\n          Specific TIDs to profile (these can be outside the PIDs selected above)\n\n      --show-unwind-info <PATH_TO_BINARY>\n          Show unwind info for given binary\n\n      --show-info <PATH_TO_BINARY>\n          Show build ID for given binary\n\n  -D, --duration <DURATION>\n          How long this agent will run in seconds\n          \n          [default: 18446744073709551615]\n\n      --libbpf-logs\n          Enable libbpf logs. This includes the BPF verifier output\n\n      --bpf-logging\n          Enable BPF programs logging\n\n      --logging <LOGGING>\n          Set lightswitch's logging level\n          \n          [default: info]\n          [possible values: trace, debug, info, warn, error]\n\n      --sample-freq <SAMPLE_FREQ_IN_HZ>\n          Per-CPU Sampling Frequency in Hz\n          \n          [default: 19]\n\n      --profile-format <PROFILE_FORMAT>\n          Output file for Flame Graph in SVG format\n          \n          [default: flame-graph]\n          [possible values: none, flame-graph, pprof]\n\n      --profile-name <PROFILE_NAME>\n          Name for the generated profile\n\n      --sender <SENDER>\n          Where to write the profile\n          \n          [default: local-disk]\n\n          Possible values:\n          - none:       Discard the profile. Used for kernel tests\n          - local-disk\n          - remote\n\n      --perf-buffer-bytes <PERF_BUFFER_BYTES>\n          Size of each profiler perf buffer, in bytes (must be a power of 2)\n          \n          [default: 524288]\n\n      --mapsize-info\n          Print eBPF map sizes after creation\n\n      --mapsize-stacks <MAPSIZE_STACKS>\n          max number of individual stacks to capture before aggregation\n          \n          [default: 100000]\n\n      --mapsize-aggregated-stacks <MAPSIZE_AGGREGATED_STACKS>\n          Derived from constant MAX_AGGREGATED_STACKS_ENTRIES - max number of unique stacks after aggregation\n          \n          [default: 10000]\n\n      --mapsize-unwind-info-chunks <MAPSIZE_UNWIND_INFO_CHUNKS>\n          max number of chunks allowed inside a shard\n          \n          [default: 5000]\n\n      --mapsize-unwind-tables <MAPSIZE_UNWIND_TABLES>\n          Derived from constant MAX_UNWIND_INFO_SHARDS\n          \n          [default: 65]\n\n      --mapsize-rate-limits <MAPSIZE_RATE_LIMITS>\n          Derived from constant MAX_PROCESSES\n          \n          [default: 5000]\n\n      --exclude-self\n          Do not profile the profiler (myself)\n\n      --symbolizer <SYMBOLIZER>\n          [default: local]\n          [possible values: local, none]\n\n  -h, --help\n          Print help (see a summary with '-h')\n"
+        "#);
     }
 
     #[rstest]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -8,7 +8,7 @@ use crossbeam_channel::bounded;
 
 use lightswitch::collector::{AggregatorCollector, Collector};
 use lightswitch::profile::symbolize_profile;
-use lightswitch::profiler::SymbolizedAggregatedProfile;
+use lightswitch::profiler::AggregatedProfile;
 use lightswitch::profiler::{Profiler, ProfilerConfig};
 
 /// Find the `nix` binary either in the $PATH or in the below hardcoded location.
@@ -70,14 +70,14 @@ impl Drop for TestProcess {
 }
 
 fn assert_any_stack_contains(
-    symbolized_profile: &SymbolizedAggregatedProfile,
+    symbolized_profile: &AggregatedProfile,
     expected_stack: &[&str],
 ) -> bool {
     for sample in symbolized_profile {
         let stack_string = sample
             .ustack
             .iter()
-            .map(|e| e.name.clone())
+            .map(|e| e.symbolization_result.clone().unwrap().unwrap().0)
             .collect::<Vec<_>>()
             .join("::");
 


### PR DESCRIPTION
Symbolizing addresses with DWARF is well known to be CPU and memory intensive. While other formats such as LLVM's GSYM [0] exist to make lookups cheap, there is still a need to fetch the debug information. Fortunately for us, it is 2024 and there are many pieces of infrastructure already in place, such as debuginfod [1]. This is something we might want to add later so lightswitch can programmatically download missing debug information, and maybe even optionally convert them to GSYM.

As of now, there is another use case that could benefit from not running a local symbolizing: remote symbolization. To perform symbolization in remote, i.e. some backend, we should just sent the raw memory addresses that make up the stack. We do this now with the `--symbolizer` flag, except for kernel symbols, which are not well supported in remote use cases, but this is something that will be tackled soon.

Test Plan
=========

Ran lots of tests locally, both locally (with and without local symbolization) and remotely too.