### PR TITLE
Handle rbp offsets that do not fit in 2 bytes

### DIFF
--- a/src/bpf/profiler.bpf.c
+++ b/src/bpf/profiler.bpf.c
@@ -452,6 +452,11 @@ int dwarf_unwind(struct bpf_perf_event_data *ctx) {
       break;
     }
 
+    if (found_rbp_type == RBP_TYPE_OFFSET_DID_NOT_FIT) {
+      bump_unwind_error_rbp_offset_did_not_fit();
+      return 1;
+    }
+
     if (found_rbp_type == RBP_TYPE_UNDEFINED_RETURN_ADDRESS) {
       LOG("[info] null return address, end of stack", unwind_state->ip);
       reached_bottom_of_stack = true;

--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -67,6 +67,7 @@ typedef struct {
 #define RBP_TYPE_EXPRESSION 3
 // Special values.
 #define RBP_TYPE_UNDEFINED_RETURN_ADDRESS 4
+#define RBP_TYPE_OFFSET_DID_NOT_FIT 5
 
 // Binary search error codes.
 #define BINARY_SEARCH_DEFAULT 0xFABADAFABADAULL
@@ -100,6 +101,7 @@ struct unwinder_stats_t {
   u64 error_binary_search_exausted_iterations;
   u64 error_sending_new_process_event;
   u64 error_cfa_offset_did_not_fit;
+  u64 error_rbp_offset_did_not_fit;
   u64 bp_non_zero_for_bottom_frame;
   u64 vdso_encountered;
   u64 jit_encountered;

--- a/src/bpf/profiler_bindings.rs
+++ b/src/bpf/profiler_bindings.rs
@@ -65,6 +65,8 @@ impl Add for unwinder_stats_t {
                 + other.error_sending_new_process_event,
             error_cfa_offset_did_not_fit: self.error_cfa_offset_did_not_fit
                 + other.error_cfa_offset_did_not_fit,
+            error_rbp_offset_did_not_fit: self.error_rbp_offset_did_not_fit
+                + other.error_rbp_offset_did_not_fit,
             bp_non_zero_for_bottom_frame: self.bp_non_zero_for_bottom_frame
                 + other.bp_non_zero_for_bottom_frame,
             vdso_encountered: self.vdso_encountered + other.vdso_encountered,

--- a/src/bpf/shared_maps.h
+++ b/src/bpf/shared_maps.h
@@ -44,6 +44,7 @@ DEFINE_COUNTER(error_chunk_not_found);
 DEFINE_COUNTER(error_binary_search_exausted_iterations);
 DEFINE_COUNTER(error_sending_new_process_event);
 DEFINE_COUNTER(error_cfa_offset_did_not_fit);
+DEFINE_COUNTER(error_rbp_offset_did_not_fit);
 DEFINE_COUNTER(bp_non_zero_for_bottom_frame);
 DEFINE_COUNTER(vdso_encountered);
 DEFINE_COUNTER(jit_encountered);


### PR DESCRIPTION
Improve the error handling and rather than just unwrapping this result causing a panic let's record this happening and move on. The unwinder will also recognise this rbp type and bump a counter.

I did not see any rbp offsets not fitting in 2 bytes but it _can_ happen and panic'ing is not acceptable.

That being said, cfa offsets are in many cases larger than what can be represented in 2 bytes and this is something that could be done in another commit, perhaps with some special larger unwind row for these cases?

Test Plan
=========

CI + ran for a while without issues