### PR TITLE
Add support for unwinding through vDSO sections

### DIFF
--- a/src/bpf/profiler.bpf.c
+++ b/src/bpf/profiler.bpf.c
@@ -374,16 +374,15 @@ int dwarf_unwind(struct bpf_perf_event_data *ctx) {
       return 1;
     }
 
-    if (mapping->type == 1) {
+    if (mapping->type == MAPPING_TYPE_ANON) {
       LOG("JIT section, stopping");
       bump_unwind_jit_encountered();
       return 1;
     }
 
-    if (mapping->type == 2) {
-      LOG("vDSO section, stopping");
+    if (mapping->type == MAPPING_TYPE_VDSO) {
+      LOG("vDSO section");
       bump_unwind_vdso_encountered();
-      return 1;
     }
 
     u64 object_relative_pc = unwind_state->ip - mapping->load_address;

--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -1,6 +1,5 @@
 #include "basic_types.h"
 
-
 // Number of frames to walk per tail call iteration.
 #define MAX_STACK_DEPTH_PER_PROGRAM 7
 // Number of BPF tail calls that will be attempted.
@@ -34,6 +33,12 @@ _Static_assert(MAX_BINARY_SEARCH_DEPTH >= UNWIND_INFO_PAGE_BIT_LEN, "unwind tabl
 #define LOW_PC(addr) (addr & LOW_PC_MASK)
 
 #define MAX_EXECUTABLE_TO_PAGE_ENTRIES 500 * 1000
+
+#define MAPPING_TYPE_FILE 0
+#define MAPPING_TYPE_ANON 1
+#define MAPPING_TYPE_VDSO 2
+
+
 typedef struct {
   u64 executable_id;
   u64 file_offset;


### PR DESCRIPTION
Rather than skipping these sections, let's fish out the ELF executable loaded by the kernel and treat it as any other object file. This could be cached but it is not done yet.

Test Plan
=========

Running the following Python script: `import time; while True: time.time()`
Unwinding vDSO works (`vdso_encountered: 12`)


```
$ cargo run -- --pids `pidof python3` --sample-freq=127
```

<img width="680" alt="image" src="https://github.com/user-attachments/assets/38af0fd8-85b1-43b0-b71c-7ad2a780022f">
