### PR TITLE
Move object file parser to its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,7 +1237,6 @@ dependencies = [
  "criterion",
  "crossbeam-channel",
  "ctrlc",
- "data-encoding",
  "errno",
  "gimli",
  "glob",
@@ -1250,6 +1249,7 @@ dependencies = [
  "libbpf-sys",
  "lightswitch-capabilities",
  "lightswitch-metadata-provider",
+ "lightswitch-object",
  "lightswitch-proto",
  "memmap2 0.9.5",
  "nix",
@@ -1262,7 +1262,6 @@ dependencies = [
  "prost",
  "rand 0.8.5",
  "reqwest",
- "ring",
  "rstest",
  "tempdir",
  "tempfile",
@@ -1297,6 +1296,17 @@ dependencies = [
  "procfs",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "lightswitch-object"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "data-encoding",
+ "memmap2 0.9.5",
+ "object",
+ "ring",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 members = [
     "lightswitch-proto",
     "lightswitch-capabilities",
-    "lightswitch-metadata-provider"
+    "lightswitch-metadata-provider",
+    "lightswitch-object"
 ]
 
 [dependencies]
@@ -23,8 +24,6 @@ perf-event-open-sys = "4.0.0"
 errno = "0.3.9"
 plain = "0.2.3"
 procfs = "0.16.0"
-ring = "0.17.8"
-data-encoding = "2.6.0"
 page_size = "0.6.0"
 clap = { version = "4.5.18", features = ["derive", "string"] }
 blazesym = "0.2.0-rc.1"
@@ -38,6 +37,7 @@ reqwest = { version = "0.12", features = ["blocking"] }
 lightswitch-metadata-provider = {path = "./lightswitch-metadata-provider"}
 lightswitch-proto = { path = "./lightswitch-proto"}
 lightswitch-capabilities = {path = "./lightswitch-capabilities"}
+lightswitch-object = {path = "./lightswitch-object"}
 ctrlc = "3.4.5"
 crossbeam-channel = "0.5.13"
 libbpf-sys = "1.4.3"

--- a/lightswitch-object/Cargo.toml
+++ b/lightswitch-object/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "lightswitch-object"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+memmap2 = "0.9.5"
+object = "0.36.4"
+ring = "0.17.8"
+anyhow = "*"
+data-encoding = "*"

--- a/lightswitch-object/src/lib.rs
+++ b/lightswitch-object/src/lib.rs
@@ -1,0 +1,5 @@
+mod object;
+
+pub use object::code_hash;
+pub use object::ObjectFile;
+pub use object::{BuildId, ElfLoad, ExecutableId};

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -4,7 +4,6 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tracing::{debug, span, Level};
 
-use crate::object::ExecutableId;
 use crate::profile::raw_to_processed;
 use crate::profile::{symbolize_profile, to_pprof};
 use crate::profiler::AggregatedProfile;
@@ -12,6 +11,7 @@ use crate::profiler::AggregatedSample;
 use crate::profiler::ObjectFileInfo;
 use crate::profiler::ProcessInfo;
 use crate::profiler::RawAggregatedProfile;
+use lightswitch_object::ExecutableId;
 
 use lightswitch_metadata_provider::metadata_provider::ThreadSafeGlobalMetadataProvider;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 pub mod bpf;
 pub mod collector;
 pub mod ksym;
-pub mod object;
 pub mod perf_events;
 pub mod profile;
 pub mod profiler;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,6 @@ use tracing_subscriber::FmtSubscriber;
 use lightswitch_capabilities::system_info::SystemInfo;
 use lightswitch_metadata_provider::metadata_provider::ThreadSafeGlobalMetadataProvider;
 
-use lightswitch::object::ObjectFile;
 use lightswitch::profile::symbolize_profile;
 use lightswitch::profile::{fold_profile, to_pprof};
 use lightswitch::profiler::{Profiler, ProfilerConfig};
@@ -32,6 +31,7 @@ use lightswitch::unwind_info::in_memory_unwind_info;
 use lightswitch::unwind_info::remove_redundant;
 use lightswitch::unwind_info::remove_unnecesary_markers;
 use lightswitch::unwind_info::UnwindInfoBuilder;
+use lightswitch_object::ObjectFile;
 
 const SAMPLE_FREQ_RANGE: RangeInclusive<usize> = 1..=1009;
 const PPROF_INGEST_URL: &str = "http://localhost:4567/pprof/new";

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -13,7 +13,6 @@ use tracing::{debug, error, span, Level};
 
 use crate::ksym::Ksym;
 use crate::ksym::KsymIter;
-use crate::object::ExecutableId;
 use crate::profiler::AggregatedProfile;
 use crate::profiler::AggregatedSample;
 use crate::profiler::Frame;
@@ -22,6 +21,7 @@ use crate::profiler::ObjectFileInfo;
 use crate::profiler::ProcessInfo;
 use crate::profiler::RawAggregatedProfile;
 use crate::usym::symbolize_native_stack_blaze;
+use lightswitch_object::ExecutableId;
 
 struct ProfileLabel {
     value: MetadataLabelValue,

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -32,13 +32,13 @@ use crate::bpf::profiler_skel::{ProfilerSkel, ProfilerSkelBuilder};
 use crate::bpf::tracers_bindings::*;
 use crate::bpf::tracers_skel::{TracersSkel, TracersSkelBuilder};
 use crate::collector::*;
-use crate::object::ElfLoad;
-use crate::object::{BuildId, ExecutableId, ObjectFile};
 use crate::perf_events::setup_perf_event;
 use crate::unwind_info::log_unwind_info_sections;
 use crate::unwind_info::CompactUnwindRow;
 use crate::unwind_info::{in_memory_unwind_info, remove_redundant, remove_unnecesary_markers};
 use crate::util::{get_online_cpus, summarize_address_range};
+use lightswitch_object::ElfLoad;
+use lightswitch_object::{BuildId, ExecutableId, ObjectFile};
 
 pub enum TracerEvent {
     ProcessExit(i32),


### PR DESCRIPTION
Also change the initialiser to not require an owned path buffer, and add some more comments.

Test Plan
=========

CI