### PR TITLE
Move shared crates to workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,12 +694,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,10 +1254,9 @@ dependencies = [
  "primal",
  "procfs",
  "prost",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "rstest",
- "tempdir",
  "tempfile",
  "thiserror",
  "tracing",
@@ -1278,7 +1271,7 @@ dependencies = [
  "errno",
  "glob",
  "libbpf-cargo",
- "libbpf-rs 0.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libbpf-rs 0.23.3 (git+https://github.com/libbpf/libbpf-rs?rev=4ebf2ac7cd509e9442aff9b9f92164f252adf2a3)",
  "libc",
  "nix",
  "perf-event-open-sys",
@@ -1316,7 +1309,7 @@ dependencies = [
  "anyhow",
  "prost",
  "prost-build",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -1879,26 +1872,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1908,23 +1888,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1953,15 +1918,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2007,15 +1963,6 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqwest"
@@ -2460,16 +2407,6 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,51 +11,67 @@ members = [
     "lightswitch-object"
 ]
 
-[dependencies]
-gimli = "0.31.0"
-object = "0.36.4"
+[workspace.dependencies]
 memmap2 = "0.9.5"
-lazy_static = "1.5.0"
 anyhow = "1.0.89"
-thiserror = "1.0.63"
+object = "0.36.4"
 # TODO: Move to a release.
 libbpf-rs = { git = "https://github.com/libbpf/libbpf-rs", rev="4ebf2ac7cd509e9442aff9b9f92164f252adf2a3", features = ["static"] }
-perf-event-open-sys = "4.0.0"
+tracing = "0.1.40"
+thiserror = "1.0.63"
 errno = "0.3.9"
-plain = "0.2.3"
+perf-event-open-sys = "4.0.0"
 procfs = "0.16.0"
+nix = { version = "0.29.0" }
+# workspace dev dependencies have to be defined here
+rand = "0.8.5"
+# workspace build dependencies have to be defined here
+libbpf-cargo = "0.23.3"
+glob = "0.3.1"
+
+[dependencies]
+gimli = "0.31.0"
+lazy_static = "1.5.0"
+plain = "0.2.3"
 page_size = "0.6.0"
 clap = { version = "4.5.18", features = ["derive", "string"] }
 blazesym = "0.2.0-rc.1"
-tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 inferno = "0.11.21"
 primal = "0.3.3"
-nix = { version = "0.29.0", features = ["user"] }
 prost = "0.13" # Needed to encode protocol buffers to bytes.
 reqwest = { version = "0.12", features = ["blocking"] }
-lightswitch-metadata-provider = {path = "./lightswitch-metadata-provider"}
-lightswitch-proto = { path = "./lightswitch-proto"}
-lightswitch-capabilities = {path = "./lightswitch-capabilities"}
-lightswitch-object = {path = "./lightswitch-object"}
 ctrlc = "3.4.5"
 crossbeam-channel = "0.5.13"
 libbpf-sys = "1.4.3"
 itertools = "0.13.0"
+lightswitch-metadata-provider = {path = "lightswitch-metadata-provider"}
+lightswitch-proto = { path = "lightswitch-proto"}
+lightswitch-capabilities = {path = "lightswitch-capabilities"}
+lightswitch-object = {path = "lightswitch-object"}
+memmap2 = { workspace = true }
+anyhow = { workspace = true }
+object = { workspace = true }
+libbpf-rs = { workspace = true }
+tracing = { workspace = true }
+perf-event-open-sys = { workspace = true }
+thiserror = { workspace = true }
+errno = { workspace = true }
+procfs = { workspace = true }
+nix = { workspace = true, features = ["user"] }
 
 [dev-dependencies]
 assert_cmd = { version = "2.0.16" }
 insta = { version = "1.40.0", features = ["yaml"] }
 rstest = "0.23.0"
-tempdir = "0.3.7"
-rand = "0.8.5"
+rand = { workspace = true }
 criterion = "0.5.1"
 tempfile = "3.13.0"
 
 [build-dependencies]
+libbpf-cargo = { workspace = true }
+glob = { workspace = true }
 bindgen = "0.70.1"
-libbpf-cargo = "0.23.3"
-glob = "0.3.1"
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/flake.nix
+++ b/flake.nix
@@ -71,14 +71,17 @@
             nativeBuildInputs = nativeBuildInputs;
             buildInputs = buildInputs ++ [
               rust-toolchain
-              # Debugging
+              # Debugging tools
               strace
               gdb
-              # Other tools
+              # Upload container image to registry
               skopeo
+              # Cargo subcommand tools
+              ## To upgrade deps
               cargo-edit
-              # snapshot testing plugin binary
+              ## Snapshot testing
               cargo-insta
+              # Commented out because this is typically not cached and it's rarely used
               # ocamlPackages.magic-trace
             ];
             hardeningDisable = [ "all" ];

--- a/lightswitch-capabilities/Cargo.toml
+++ b/lightswitch-capabilities/Cargo.toml
@@ -4,15 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.89"
-thiserror = "1.0.64"
-libbpf-rs = { version = "0.23.3", features = ["static"] }
-perf-event-open-sys = "4.0.0"
 libc = "0.2.159"
-errno = "0.3.9"
-tracing = "0.1.40"
-nix = { version = "0.29.0", features = ["user"] }
+anyhow = { workspace = true}
+thiserror = { workspace = true}
+libbpf-rs = { workspace = true}
+perf-event-open-sys = { workspace = true}
+errno = { workspace = true}
+tracing = { workspace = true}
+nix = { workspace = true}
 
 [build-dependencies]
-libbpf-cargo = "0.23.3"
-glob = "0.3.1"
+libbpf-cargo = { workspace = true}
+glob = { workspace = true}

--- a/lightswitch-metadata-provider/Cargo.toml
+++ b/lightswitch-metadata-provider/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.86"
 lru = "0.12.4"
-nix = { version = "0.29.0", features = ["user", "process"] }
-procfs = "0.16.0"
-tracing = "0.1.40"
-thiserror = "1.0.63"
+nix = { workspace = true, features = ["user", "process"] }
+anyhow = { workspace = true }
+procfs = { workspace = true }
+tracing = { workspace = true }
+thiserror = { workspace = true }

--- a/lightswitch-object/Cargo.toml
+++ b/lightswitch-object/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-memmap2 = "0.9.5"
-object = "0.36.4"
+data-encoding = "2.6.0"
 ring = "0.17.8"
-anyhow = "*"
-data-encoding = "*"
+memmap2 = { workspace = true }
+object = { workspace = true }
+anyhow = { workspace = true }

--- a/lightswitch-proto/Cargo.toml
+++ b/lightswitch-proto/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 [dependencies]
 prost = "0.13"
-anyhow = "1.0.89"
+anyhow = { workspace = true }
 
 [dev-dependencies]
-rand = "0.8.5"
+rand = { workspace = true }
 
 [build-dependencies]
 prost-build = "0.13.3"


### PR DESCRIPTION
Rather than have the same entry multiple times over the different crates, or even worse, accidentally having different versions / features, which would cause more code to be compiled, let's have this in a workspace.dependencies section and refer to it in the various crates.

The build times are pretty much the same

* Before: 72.4s (1m 12.4s)
* After: 73.1s (1m 13.1s)

Test Plan
=========

CI