### PR TITLE
object: Improve correctness

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -140,12 +140,12 @@ impl Default for Profiler<'_> {
 }
 
 /// Extract the vdso object file loaded in the address space of each process.
-fn fetch_vdso_info<'a>(
+fn fetch_vdso_info(
     pid: Pid,
     start_addr: u64,
     end_addr: u64,
     offset: u64,
-) -> Result<(PathBuf, ObjectFile<'a>)> {
+) -> Result<(PathBuf, ObjectFile)> {
     // Read raw memory
     let file = fs::File::open(format!("/proc/{}/mem", pid))?;
     let size = end_addr - start_addr;


### PR DESCRIPTION
object: Improve correctness
Due to the fact that `object::File` takes a reference to the mmap-ed
file, we needed to do some awful lifetime hacks to fit it in the API we
wanted. While getting rid of the raw pointer and drop impl, Ricardo
noticed that there was some lurking UB too, so this fixes it as well.

Co-authored-by: Ricardo Delfin <me@rdelfin.com>

Test Plan
=========

CI