### PR TITLE
Make changes to publish crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,7 +1418,7 @@ dependencies = [
  "errno",
  "glob",
  "libbpf-cargo",
- "libbpf-rs 0.23.3 (git+https://github.com/libbpf/libbpf-rs?rev=4ebf2ac7cd509e9442aff9b9f92164f252adf2a3)",
+ "libbpf-rs 0.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
  "nix",
  "perf-event-open-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "lightswitch"
 version = "0.1.0"
 edition = "2021"
+description = "CPU profiler as a library for Linux suitable for on-demand and continuous profiling"
+license = "MIT"
+repository = "https://github.com/javierhonduco/lightswitch"
 
 [workspace]
 members = [
@@ -45,10 +48,10 @@ ctrlc = "3.4.5"
 crossbeam-channel = "0.5.13"
 libbpf-sys = "1.5.0"
 itertools = "0.13.0"
-lightswitch-metadata = {path = "lightswitch-metadata"}
-lightswitch-proto = { path = "lightswitch-proto"}
-lightswitch-capabilities = {path = "lightswitch-capabilities"}
-lightswitch-object = {path = "lightswitch-object"}
+lightswitch-metadata = { path = "lightswitch-metadata", version = "0.1.0" }
+lightswitch-proto = { path = "lightswitch-proto", version = "0.1.0" }
+lightswitch-capabilities = { path = "lightswitch-capabilities", version = "0.1.0" }
+lightswitch-object = { path = "lightswitch-object", version = "0.1.0" }
 memmap2 = { workspace = true }
 anyhow = { workspace = true }
 object = { workspace = true }

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,8 @@
               cargo-insta
               ## Remove unused deps
               cargo-shear
+              ## Release to crates.io
+              cargo-release
               # Commented out because this is typically not cached and it's rarely used
               # ocamlPackages.magic-trace
             ];

--- a/lightswitch-capabilities/Cargo.toml
+++ b/lightswitch-capabilities/Cargo.toml
@@ -2,16 +2,21 @@
 name = "lightswitch-capabilities"
 version = "0.1.0"
 edition = "2021"
+description = "Discover which BPF features are available"
+license = "MIT"
+repository = "https://github.com/javierhonduco/lightswitch"
 
 [dependencies]
 libc = "0.2.162"
 anyhow = { workspace = true}
 thiserror = { workspace = true}
-libbpf-rs = { workspace = true}
+# TODO: change to the workspace version once the blocker is removed and we can upgrade
+# to a published version everywhere.
+libbpf-rs = { version = "0.23.0", features = ["static"] }
 perf-event-open-sys = { workspace = true}
 errno = { workspace = true}
 tracing = { workspace = true}
-nix = { workspace = true}
+nix = { workspace = true, features = ["feature"] }
 
 [build-dependencies]
 libbpf-cargo = { workspace = true}

--- a/lightswitch-metadata/Cargo.toml
+++ b/lightswitch-metadata/Cargo.toml
@@ -2,6 +2,9 @@
 name = "lightswitch-metadata"
 version = "0.1.0"
 edition = "2021"
+description = "Provides metadata used by profilers and debuggers"
+license = "MIT"
+repository = "https://github.com/javierhonduco/lightswitch"
 
 [dependencies]
 lru = "0.12.5"

--- a/lightswitch-object/Cargo.toml
+++ b/lightswitch-object/Cargo.toml
@@ -2,6 +2,9 @@
 name = "lightswitch-object"
 version = "0.1.0"
 edition = "2021"
+description = "Deals with object files"
+license = "MIT"
+repository = "https://github.com/javierhonduco/lightswitch"
 
 [dependencies]
 data-encoding = "2.6.0"

--- a/lightswitch-proto/Cargo.toml
+++ b/lightswitch-proto/Cargo.toml
@@ -2,6 +2,9 @@
 name = "lightswitch-proto"
 version = "0.1.0"
 edition = "2021"
+description = "Protocol buffers wrappers for use in profiling tools"
+license = "MIT"
+repository = "https://github.com/javierhonduco/lightswitch"
 
 [dependencies]
 prost = "0.13"


### PR DESCRIPTION
Test Plan
=========

CI and crates (except `lightswitch`) were published to crates.io with `cargo release --package lightswitch --execute`