### PR TITLE
Use `p_filesz` instead of `p_memsz` for address normalization

### DIFF
--- a/lightswitch-object/src/object.rs
+++ b/lightswitch-object/src/object.rs
@@ -30,7 +30,7 @@ pub type ExecutableId = u64;
 pub struct ElfLoad {
     pub p_offset: u64,
     pub p_vaddr: u64,
-    pub p_memsz: u64,
+    pub p_filesz: u64,
 }
 
 #[derive(Debug)]
@@ -127,7 +127,7 @@ impl ObjectFile {
                         elf_loads.push(ElfLoad {
                             p_offset: segment.p_offset(endian) as u64,
                             p_vaddr: segment.p_vaddr(endian) as u64,
-                            p_memsz: segment.p_memsz(endian) as u64,
+                            p_filesz: segment.p_filesz(endian) as u64,
                         });
                     }
                 }
@@ -144,7 +144,7 @@ impl ObjectFile {
                         elf_loads.push(ElfLoad {
                             p_offset: segment.p_offset(endian),
                             p_vaddr: segment.p_vaddr(endian),
-                            p_memsz: segment.p_memsz(endian),
+                            p_filesz: segment.p_filesz(endian),
                         });
                     }
                 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -167,7 +167,7 @@ impl ObjectFileInfo {
         let offset = virtual_address - mapping.start_addr + mapping.offset;
 
         for segment in &self.elf_load_segments {
-            let address_range = segment.p_vaddr..(segment.p_vaddr + segment.p_memsz);
+            let address_range = segment.p_vaddr..(segment.p_vaddr + segment.p_filesz);
             if address_range.contains(&offset) {
                 return Some(offset - segment.p_offset + segment.p_vaddr);
             }
@@ -244,7 +244,7 @@ mod tests {
         object_file_info.elf_load_segments = vec![ElfLoad {
             p_offset: 0x1,
             p_vaddr: 0x0,
-            p_memsz: 0x20,
+            p_filesz: 0x20,
         }];
         assert_eq!(
             object_file_info.normalized_address(0x110, &mapping),
@@ -254,7 +254,7 @@ mod tests {
         object_file_info.elf_load_segments = vec![ElfLoad {
             p_offset: 0x0,
             p_vaddr: 0x0,
-            p_memsz: 0x5,
+            p_filesz: 0x5,
         }];
         assert!(object_file_info
             .normalized_address(0x110, &mapping)


### PR DESCRIPTION
Saw https://github.com/libbpf/blazesym/pull/875 by pure chance and we have the same bug in our normalization logic.

Thanks so much, @danielocfb!

Test Plan
=========

Integration test pass. Would be good to add a regression tests for this.