### PR TITLE
Use forked libbpf-rs to publish crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,7 +1306,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
- "libbpf-rs 0.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libbpf-rs",
  "memmap2 0.5.10",
  "regex",
  "semver",
@@ -1329,9 +1329,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "libbpf-rs"
+name = "libbpf-rs-lightswitch"
 version = "0.23.3"
-source = "git+https://github.com/libbpf/libbpf-rs?rev=4ebf2ac7cd509e9442aff9b9f92164f252adf2a3#4ebf2ac7cd509e9442aff9b9f92164f252adf2a3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d8efd9727c50d463ca328574a2c72e7adf71ac6e9d2e220e8c7cbda56ef3b52"
 dependencies = [
  "bitflags",
  "libbpf-sys",
@@ -1386,7 +1387,7 @@ dependencies = [
  "itertools 0.13.0",
  "lazy_static",
  "libbpf-cargo",
- "libbpf-rs 0.23.3 (git+https://github.com/libbpf/libbpf-rs?rev=4ebf2ac7cd509e9442aff9b9f92164f252adf2a3)",
+ "libbpf-rs-lightswitch",
  "libbpf-sys",
  "lightswitch-capabilities",
  "lightswitch-metadata",
@@ -1418,7 +1419,7 @@ dependencies = [
  "errno",
  "glob",
  "libbpf-cargo",
- "libbpf-rs 0.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libbpf-rs-lightswitch",
  "libc",
  "nix",
  "perf-event-open-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ members = [
 memmap2 = "0.9.5"
 anyhow = "1.0.93"
 object = "0.36.5"
-# TODO: Move to a release.
-libbpf-rs = { git = "https://github.com/libbpf/libbpf-rs", rev="4ebf2ac7cd509e9442aff9b9f92164f252adf2a3", features = ["static"] }
+# TODO: Move off this fork once all the changes we need land upstream.
+libbpf-rs = { package = "libbpf-rs-lightswitch", version = "0.23.3", features = ["static"] }
 tracing = "0.1.40"
 thiserror = "2.0.3"
 errno = "0.3.9"

--- a/lightswitch-capabilities/Cargo.toml
+++ b/lightswitch-capabilities/Cargo.toml
@@ -10,9 +10,7 @@ repository = "https://github.com/javierhonduco/lightswitch"
 libc = "0.2.162"
 anyhow = { workspace = true}
 thiserror = { workspace = true}
-# TODO: change to the workspace version once the blocker is removed and we can upgrade
-# to a published version everywhere.
-libbpf-rs = { version = "0.23.0", features = ["static"] }
+libbpf-rs = { workspace = true}
 perf-event-open-sys = { workspace = true}
 errno = { workspace = true}
 tracing = { workspace = true}


### PR DESCRIPTION
In order to publish in certain environments every dependency has to be present in crates.io. We have a couple of changes waiting upstream to be cut into a release. Until then, let's use this fork.

Test Plan
=========

CI.