### PR TITLE
perf: Read debug info in streaming / chunks

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -1553,7 +1553,7 @@ impl Profiler {
 
                     // We want to open the file as quickly as possible to minimise the chances of races
                     // if the file is deleted.
-                    let mut file = match fs::File::open(&abs_path) {
+                    let file = match fs::File::open(&abs_path) {
                         Ok(f) => f,
                         Err(e) => {
                             debug!("failed to open file {} due to {:?}", abs_path, e);
@@ -1628,7 +1628,7 @@ impl Profiler {
                             &name,
                             &build_id,
                             executable_id,
-                            &mut file,
+                            &abs_path,
                         );
                         debug!("debug info manager add result {:?}", res);
                     } else {


### PR DESCRIPTION
Rather than allocating space to store it all in memory. This was done like this before as during prototyping I did not know if reqwest would also do this or stream the file.

I've since memory profiled reqwest and checked its source code and it doesn't keep the whole body in memory.

Test Plan
=========

Manually checked that it continues to work and that the file is read in chunks with a memory profiler (heaptrack).