### PR TITLE
ci: Run cargo check instead of build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
     - uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Set up nix dev env
       run: nix develop --command echo 0
-    - name: Run `cargo build`
-      run: nix develop --ignore-environment --command cargo build
+    - name: Run `cargo check`
+      run: nix develop --ignore-environment --command cargo check
     - name: Run `cargo clippy`
       run: nix develop --command cargo clippy --workspace --all-targets -- -D warnings
     - name: Run `cargo test`


### PR DESCRIPTION
As it's faster and a full build isn't really needed, we just want to make sure that the code can compile. No need to produce an executable.