### PR TITLE
Add initial arm64 support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,5 +4,8 @@ rustflags = ["-Cforce-frame-pointers=yes"]
 [target.x86_64-unknown-linux-gnu]
 runner = "sudo -E"
 
+[target.aarch64-unknown-linux-gnu]
+runner = "sudo -E"
+
 [alias]
 xtask = "run --package xtask --"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,3 +47,5 @@ jobs:
         run: nix develop --command echo 0
       - name: Run `cargo check`
         run: nix develop --ignore-environment --command cargo check
+      - name: Run `cargo test`
+        run: nix develop --command cargo test --workspace

--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -177,6 +177,7 @@ typedef struct {
   unsigned long long ip;
   unsigned long long sp;
   unsigned long long bp;
+  unsigned long long lr;
   int tail_calls;
 
   stack_count_key_t stack_key;

--- a/src/process.rs
+++ b/src/process.rs
@@ -117,6 +117,7 @@ pub struct ObjectFileInfo {
     pub is_dyn: bool,
     pub references: i64,
     pub native_unwind_info_size: Option<u64>,
+    pub is_vdso: bool,
 }
 
 impl Clone for ObjectFileInfo {
@@ -128,6 +129,7 @@ impl Clone for ObjectFileInfo {
             is_dyn: self.is_dyn,
             references: self.references,
             native_unwind_info_size: self.native_unwind_info_size,
+            is_vdso: self.is_vdso,
         }
     }
 }
@@ -202,6 +204,7 @@ mod tests {
             is_dyn: false,
             references: 1,
             native_unwind_info_size: None,
+            is_vdso: false,
         };
 
         remove_file(file_path).unwrap();
@@ -221,6 +224,7 @@ mod tests {
             is_dyn: false,
             references: 0,
             native_unwind_info_size: None,
+            is_vdso: false,
         };
 
         let mapping = ExecutableMapping {

--- a/src/unwind_info/types.rs
+++ b/src/unwind_info/types.rs
@@ -85,5 +85,11 @@ lazy_static! {
     ].map(|a| a.0);
 }
 
-pub const RBP_X86: gimli::Register = gimli::Register(6);
-pub const RSP_X86: gimli::Register = gimli::Register(7);
+// Source: https://gitlab.com/x86-psABIs/x86-64-ABI/-/jobs/artifacts/d725a372/raw/x86-64-ABI/abi.pdf?job=build
+// > Figure 3.36: DWARF Register Number Mapping
+pub const X86_FP: gimli::Register = gimli::Register(6); // Frame Pointer ($rbp)
+pub const X86_SP: gimli::Register = gimli::Register(7); // Stack Pointer ($rsp)
+
+// Source: https://github.com/ARM-software/abi-aa/blob/05abf4f7/aadwarf64/aadwarf64.rst#41dwarf-register-names
+pub const ARM64_FP: gimli::Register = gimli::Register(29); // Frame Pointer (x29)
+pub const ARM64_SP: gimli::Register = gimli::Register(31); // Stack Pointer (sp)

--- a/src/util/arch.rs
+++ b/src/util/arch.rs
@@ -1,0 +1,15 @@
+#[derive(PartialEq)]
+pub enum Architecture {
+    Arm64,
+    X86,
+}
+
+#[cfg(target_arch = "aarch64")]
+pub fn architecture() -> Architecture {
+    Architecture::Arm64
+}
+
+#[cfg(target_arch = "x86_64")]
+pub fn architecture() -> Architecture {
+    Architecture::X86
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,9 @@
+mod arch;
 mod cpu;
 mod lpm;
 
+pub use arch::architecture;
+pub use arch::Architecture;
 pub use cpu::get_online_cpus;
 pub use lpm::summarize_address_range;
 pub use lpm::AddressBlockRange;


### PR DESCRIPTION
This commit adds support for the arm64 (aarch64) architecture. This is achived by adapting the compact unwind information generation to deal with the DWARF registers that this architecture maps to and by modifying the unwinder.

These changes support PAC (Pointer Authentication Code), see test plan for more details.

While working on this feature I realised that the vDSO included in Ubuntu 24.10 (6.11.0-12-generic) does not contain unwind information. In the future we should synthetise it which should be easy enough as it seems to be compiled with frame pointers.

Test Plan
=========

Ran tests locally on the arm64 machine mentioned above, and the PAC-enabled binary (see tests/testprogs/). The tests will also be run for this arch.

```
2025-01-22T12:59:32.726079Z  INFO lightswitch::profiler: unwinder stats: unwinder_stats_t { total: 44, success_dwarf: 44, error_truncated: 0, error_unsupported_expression: 0, error_unsupported_frame_pointer_action: 0, error_unsupported_cfa_register: 0, error_previous_rsp_zero: 0, error_previous_rip_zero: 0, error_previous_rbp_zero: 0, error_should_never_happen: 0, error_mapping_not_found: 0, error_mapping_does_not_contain_pc: 0, error_chunk_not_found: 0, error_binary_search_exhausted_iterations: 0, error_sending_new_process_event: 0, error_cfa_offset_did_not_fit: 0, error_rbp_offset_did_not_fit: 0, bp_non_zero_for_bottom_frame: 0, vdso_encountered: 0, jit_encountered: 0 }
```