### PR TITLE
metadata: Use the thread group id (tgid) for the main task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "lightswitch-metadata"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "lru",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ ctrlc = "3.4.5"
 crossbeam-channel = "0.5.14"
 libbpf-sys = "1.5.0"
 itertools = "0.14.0"
-lightswitch-metadata = { path = "lightswitch-metadata", version = "0.1.0" }
+lightswitch-metadata = { path = "lightswitch-metadata", version = "0.1.1" }
 lightswitch-proto = { path = "lightswitch-proto", version = "0.1.0" }
 lightswitch-capabilities = { path = "lightswitch-capabilities", version = "0.1.0" }
 lightswitch-object = { path = "lightswitch-object", version = "0.2.0" }

--- a/lightswitch-metadata/Cargo.toml
+++ b/lightswitch-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightswitch-metadata"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Provides metadata used by profilers and debuggers"
 license = "MIT"


### PR DESCRIPTION
Rather than the process group id (pgrp) used as the main process for signal delivery. While in many instances they match, this code is not correct.

Test Plan
=========
Manual tests