### PR TITLE
Increase unwind information batch size

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -872,7 +872,7 @@ impl Profiler {
     }
 
     fn add_bpf_unwind_info(inner: &MapHandle, unwind_info: &[CompactUnwindRow]) {
-        let chunk_size = 25_000;
+        let chunk_size = std::cmp::min(500_000, unwind_info.len()); // 500k entries fit in 8MB.
         let mut keys: Vec<u8> = Vec::with_capacity(std::mem::size_of::<u32>() * chunk_size);
         let mut values: Vec<u8> =
             Vec::with_capacity(std::mem::size_of::<stack_unwind_row_t>() * chunk_size);


### PR DESCRIPTION
The current default might be a bit too conservative on the low side. CPU profiles show quite a bit of time spent calling `update_batch` which should be reduced by increasing the batch size. I considered batches as large as the whole unwind information but these can get quite large in the biggest unwind information buckets, so choosing something between 500k entries or the unwind information length, whichever is smaller.

Test Plan
=========

ci