### PR TITLE
Increase debuginfo upload timeout

### DIFF
--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -145,10 +145,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         DebugInfoBackend::Copy => Box::new(DebugInfoBackendFilesystem {
             path: PathBuf::from("/tmp"),
         }),
-        DebugInfoBackend::Remote => Box::new(DebugInfoBackendRemote {
-            http_client_timeout: Duration::from_millis(500),
+        DebugInfoBackend::Remote => Box::new(DebugInfoBackendRemote::new(
             server_url,
-        }),
+            Duration::from_millis(500),
+            Duration::from_secs(15),
+        )?),
     };
 
     let profiler_config = ProfilerConfig {

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -1635,7 +1635,17 @@ impl Profiler {
                         let res = self
                             .debug_info_manager
                             .add_if_not_present(&name, build_id, &abs_path);
-                        debug!("debug info manager add result {:?}", res);
+                        match res {
+                            Ok(_) => {
+                                debug!("debuginfo add_if_not_present succeded {:?}", res);
+                            }
+                            Err(e) => {
+                                error!(
+                                    "debuginfo add_if_not_present failed with: {}",
+                                    e.root_cause()
+                                );
+                            }
+                        }
                     } else {
                         debug!(
                             "could not find debug information for {}",


### PR DESCRIPTION
As it was too slow for larger files. This issue is now more apparent as the file is read in chunks, which is good to reduce peak memory usage, but might take slightly longer.

Also now the two http clients are created once, in the constructor, and the timeout of the two calls are configurable separately.

Test Plan
=========

ci