### PR TITLE
build: Add optimised release target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,11 @@ bindgen = "0.71.1"
 [profile.dev.package."*"]
 opt-level = 3
 
+[profile.release-lto]
+inherits = "release"
+lto = true
+codegen-unit = 1
+
 [[bench]]
 name = "benchmark"
 harness = false


### PR DESCRIPTION
One of the main reasons why this project is written in Rust is that it uses LLVM to codegen and we can get highly optimised code, which is very important to reduce overhead, without compromising on memory safety and modern constructs.

So far `--release` was used, which is basically equivalent to $CC's -O3. Let's use full LTO and 1 single codegen as this can help reduce code size.

See https://doc.rust-lang.org/rustc/codegen-options/index.html

Future work
===========
Will adjust the release pipelines before the next release

Test Plan
=========

Ran `cargo run --target release-lto`. Checked that the binary is indeed smaller

```
$ ls -lah  target/release/lightswitch
-rwxr-xr-x 2 javierhonduco javierhonduco 8.7M Feb  6 12:08 target/release/lightswitch
$ ls -lah  target/release-lto/lightswitch
-rwxr-xr-x 2 javierhonduco javierhonduco 6.8M Feb  6 12:12 target/release-lto/lightswitch
```