### PR TITLE
ci: Do not cancel running jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,6 @@ on:
       branches:
         - main
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   ci:
     runs-on: ubuntu-22.04

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -5,10 +5,6 @@ on:
       branches:
         - main
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   container:
     runs-on: ubuntu-22.04

--- a/.github/workflows/static-build-and-upload.yml
+++ b/.github/workflows/static-build-and-upload.yml
@@ -5,10 +5,6 @@ on:
       branches:
         - main
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   static-build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -5,10 +5,6 @@ on:
       branches:
         - main
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   vmtests:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
The deleted config was setup to cancel old jobs running on PRs after a force push but this also cancel jobs running on pushs to the main branch. This is quite annoying so deleting it and will tackle the PR job duplication if it's still an issue

Test Plan
=========
CI