### PR TITLE
ci: Migrate from nix magic cache to flakehub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@main
     - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - uses: DeterminateSystems/flakehub-cache-action@main
     - name: Set up nix dev env
       run: nix develop --command echo 0
     - name: Run `cargo check`
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@main
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/flakehub-cache-action@main
       - name: Set up nix dev env
         run: nix develop --command echo 0
       - name: Run `cargo check`

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@main
     - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - uses: DeterminateSystems/flakehub-cache-action@main
 
     - name: Set up nix dev env
       run: nix develop --command echo 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@main
     - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - uses: DeterminateSystems/flakehub-cache-action@main
     - name: Set up nix dev env
       run: nix develop --command echo 0
     - name: Run `cargo test`

--- a/.github/workflows/static-build-and-upload.yml
+++ b/.github/workflows/static-build-and-upload.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@main
     - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - uses: DeterminateSystems/flakehub-cache-action@main
 
     - name: Set up nix dev env
       run: nix develop --command echo 0

--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@main
     - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - uses: DeterminateSystems/flakehub-cache-action@main
 
     - name: Install system dependencies
       run: |


### PR DESCRIPTION
tldr GitHub deprecated an API without a proper alternative, more details in https://determinate.systems/posts/magic-nix-cache-free-tier-eol/

Test Plan
=========

CI