### PR TITLE
Bump lightswitch version to v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "lightswitch"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "lightswitch-metadata"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "lru",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "lightswitch-object"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "data-encoding",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "lightswitch-proto"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightswitch"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "CPU profiler as a library for Linux suitable for on-demand and continuous profiling"
 license = "MIT"
@@ -47,10 +47,10 @@ ctrlc = "3.4.5"
 crossbeam-channel = "0.5.14"
 libbpf-sys = "1.5.0"
 itertools = "0.14.0"
-lightswitch-metadata = { path = "lightswitch-metadata", version = "0.1.1" }
+lightswitch-metadata = { path = "lightswitch-metadata", version = "0.2.0" }
 lightswitch-proto = { path = "lightswitch-proto", version = "0.1.0" }
 lightswitch-capabilities = { path = "lightswitch-capabilities", version = "0.1.0" }
-lightswitch-object = { path = "lightswitch-object", version = "0.2.0" }
+lightswitch-object = { path = "lightswitch-object", version = "0.2.1" }
 memmap2 = { workspace = true }
 anyhow = { workspace = true }
 object = { workspace = true }

--- a/lightswitch-metadata/Cargo.toml
+++ b/lightswitch-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightswitch-metadata"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Provides metadata used by profilers and debuggers"
 license = "MIT"

--- a/lightswitch-object/Cargo.toml
+++ b/lightswitch-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightswitch-object"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Deals with object files"
 license = "MIT"

--- a/lightswitch-proto/Cargo.toml
+++ b/lightswitch-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightswitch-proto"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Protocol buffers wrappers for use in profiling tools"
 license = "MIT"


### PR DESCRIPTION
In preparation to a release. Also bump the other workspace crates too.