### PR TITLE
Add subcommands for object, system, and unwind info

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use clap::Subcommand;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -50,25 +51,18 @@ pub(crate) enum DebugInfoBackend {
     Remote,
 }
 
+#[derive(Subcommand, Debug)]
+pub(crate) enum Commands {
+    ObjectInfo { path: String },
+    ShowUnwind { path: String },
+    SystemInfo,
+}
+
 #[derive(Parser, Debug)]
 pub(crate) struct CliArgs {
     /// Specific PIDs to profile
     #[arg(long)]
     pub(crate) pids: Vec<i32>,
-    /// Specific TIDs to profile (these can be outside the PIDs selected above)
-    #[arg(long)]
-    pub(crate) tids: Vec<i32>,
-    /// Show unwind info for given binary
-    #[arg(long, value_name = "PATH_TO_BINARY",
-        conflicts_with_all = ["pids", "tids", "show_info", "duration", "sample_freq", "profile_name"]
-    )]
-    pub(crate) show_unwind_info: Option<String>,
-    /// Show build ID for given binary
-    #[arg(long, value_name = "PATH_TO_BINARY",
-        conflicts_with_all = ["pids", "tids", "duration",
-            "sample_freq", "profile_name"]
-    )]
-    pub(crate) show_info: Option<String>,
     /// How long this agent will run in seconds
     #[arg(short='D', long, default_value = ProfilerConfig::default().duration.as_secs().to_string(),
         value_parser = parse_duration)]
@@ -158,4 +152,6 @@ pub(crate) struct CliArgs {
     pub(crate) unsafe_start: bool,
     #[arg(long, help = "force perf buffers even if ring buffers can be used")]
     pub(crate) force_perf_buffer: bool,
+    #[command(subcommand)]
+    pub(crate) command: Option<Commands>,
 }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -18,7 +18,7 @@ use lightswitch::debug_info::DebugInfoManager;
 use lightswitch_metadata::metadata_provider::GlobalMetadataProvider;
 use nix::unistd::Uid;
 use prost::Message;
-use tracing::{debug, error, info, Level};
+use tracing::{error, info, Level};
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::FmtSubscriber;
 
@@ -28,11 +28,13 @@ use lightswitch_metadata::metadata_provider::ThreadSafeGlobalMetadataProvider;
 use lightswitch::debug_info::{
     DebugInfoBackendFilesystem, DebugInfoBackendNull, DebugInfoBackendRemote,
 };
+use lightswitch::kernel::kernel_build_id;
 use lightswitch::profile::symbolize_profile;
 use lightswitch::profile::{fold_profile, to_pprof};
 use lightswitch::profiler::{Profiler, ProfilerConfig};
 use lightswitch::unwind_info::compact_unwind_info;
 use lightswitch::unwind_info::CompactUnwindInfoBuilder;
+use lightswitch_object::kernel::kaslr_offset;
 use lightswitch_object::ObjectFile;
 
 mod args;
@@ -40,6 +42,7 @@ mod killswitch;
 mod validators;
 
 use crate::args::CliArgs;
+use crate::args::Commands;
 use crate::args::DebugInfoBackend;
 use crate::args::LoggingLevel;
 use crate::args::ProfileFormat;
@@ -83,11 +86,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         start_deadlock_detector();
     }
 
-    if let Some(path) = args.show_unwind_info {
-        show_unwind_info(&path);
-        return Ok(());
-    }
-
     let subscriber = FmtSubscriber::builder()
         .with_max_level(match args.logging {
             LoggingLevel::Trace => Level::TRACE,
@@ -102,9 +100,25 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-    if let Some(path) = args.show_info {
-        show_object_file_info(&path);
-        return Ok(());
+    match args.command {
+        None => {} // record profiles by default
+        Some(Commands::ObjectInfo { path }) => {
+            show_object_file_info(&path);
+            return Ok(());
+        }
+        Some(Commands::ShowUnwind { path }) => {
+            show_unwind_info(&path);
+            return Ok(());
+        }
+        Some(Commands::SystemInfo) => {
+            println!("- system info: {:?}", SystemInfo::new());
+            println!("- kernel build id: {:?}", kernel_build_id());
+            if let Ok(aslr_offset) = kaslr_offset() {
+                println!("- kernel ASLR offset: 0x{:x}", aslr_offset);
+            }
+
+            return Ok(());
+        }
     }
 
     if !Uid::current().is_root() {
@@ -117,10 +131,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         std::process::exit(1)
     };
 
-    debug!("system_info = {:?}", system_info);
-
     if !system_info.has_minimal_requirements() {
         error!("Some start up requirements could not be met!");
+        error!("system_info = {:?}", system_info);
         std::process::exit(1);
     }
 
@@ -297,11 +310,16 @@ fn show_unwind_info(path: &str) {
 }
 
 fn show_object_file_info(path: &str) {
-    let objet_file = ObjectFile::new(&PathBuf::from(path)).unwrap();
-    println!("build id {:?}", objet_file.build_id());
-    let unwind_info: Result<CompactUnwindInfoBuilder<'_>, anyhow::Error> =
-        CompactUnwindInfoBuilder::with_callback(path, |_| {});
-    println!("unwind info {:?}", unwind_info.unwrap().process());
+    let object_file = ObjectFile::new(&PathBuf::from(path)).unwrap();
+    println!("- build id: {:?}", object_file.build_id());
+    if let Ok(executable_id) = object_file.build_id().id() {
+        println!("- executable id: 0x{:x}", executable_id);
+    }
+    let unwind_info = CompactUnwindInfoBuilder::with_callback(path, |_| {});
+    println!("- unwind info: {:?}", unwind_info.unwrap().process());
+    println!("- go: {:?}", object_file.is_go());
+    println!("- dynamic: {:?}", object_file.is_dynamic());
+    println!("- load segments: {:?}", object_file.elf_load_segments());
 }
 
 #[cfg(test)]
@@ -325,7 +343,7 @@ mod tests {
         cmd.arg("--help");
         cmd.assert().success();
         let actual = String::from_utf8(cmd.unwrap().stdout).unwrap();
-        insta::assert_yaml_snapshot!(actual, @r#""Usage: lightswitch [OPTIONS]\n\nOptions:\n      --pids <PIDS>\n          Specific PIDs to profile\n\n      --tids <TIDS>\n          Specific TIDs to profile (these can be outside the PIDs selected above)\n\n      --show-unwind-info <PATH_TO_BINARY>\n          Show unwind info for given binary\n\n      --show-info <PATH_TO_BINARY>\n          Show build ID for given binary\n\n  -D, --duration <DURATION>\n          How long this agent will run in seconds\n          \n          [default: 18446744073709551615]\n\n      --libbpf-debug\n          Enable libbpf logs. This includes the BPF verifier output\n\n      --bpf-logging\n          Enable BPF programs logging\n\n      --logging <LOGGING>\n          Set lightswitch's logging level\n          \n          [default: info]\n          [possible values: trace, debug, info, warn, error]\n\n      --sample-freq <SAMPLE_FREQ_IN_HZ>\n          Per-CPU Sampling Frequency in Hz\n          \n          [default: 19]\n\n      --profile-format <PROFILE_FORMAT>\n          Output file for Flame Graph in SVG format\n          \n          [default: flame-graph]\n          [possible values: none, flame-graph, pprof]\n\n      --profile-path <PROFILE_PATH>\n          Path for the generated profile\n\n      --profile-name <PROFILE_NAME>\n          Name for the generated profile\n\n      --sender <SENDER>\n          Where to write the profile\n          \n          [default: local-disk]\n\n          Possible values:\n          - none:       Discard the profile. Used for kernel tests\n          - local-disk\n          - remote\n\n      --server-url <SERVER_URL>\n          \n\n      --perf-buffer-bytes <PERF_BUFFER_BYTES>\n          Size of each profiler perf buffer, in bytes (must be a power of 2)\n          \n          [default: 524288]\n\n      --mapsize-info\n          Print eBPF map sizes after creation\n\n      --mapsize-stacks <MAPSIZE_STACKS>\n          max number of individual stacks to capture before aggregation\n          \n          [default: 100000]\n\n      --mapsize-aggregated-stacks <MAPSIZE_AGGREGATED_STACKS>\n          max number of unique stacks after aggregation\n          \n          [default: 10000]\n\n      --mapsize-rate-limits <MAPSIZE_RATE_LIMITS>\n          max number of rate limit entries\n          \n          [default: 5000]\n\n      --exclude-self\n          Do not profile the profiler (myself)\n\n      --symbolizer <SYMBOLIZER>\n          [default: local]\n          [possible values: local, none]\n\n      --debug-info-backend <DEBUG_INFO_BACKEND>\n          [default: none]\n          [possible values: none, copy, remote]\n\n      --max-native-unwind-info-size-mb <MAX_NATIVE_UNWIND_INFO_SIZE_MB>\n          approximate max size in megabytes used for the BPF maps that hold unwind information\n          \n          [default: 2147483647]\n\n      --enable-deadlock-detector\n          enable parking_lot's deadlock detector\n\n      --cache-dir-base <CACHE_DIR_BASE>\n          [default: /tmp]\n\n      --killswitch-path-override <KILLSWITCH_PATH_OVERRIDE>\n          Override the default path to the killswitch file (/tmp/lighswitch/killswitch) which prevents the profiler from starting\n\n      --unsafe-start\n          Force the profiler to start even if the system killswitch is enabled\n\n      --force-perf-buffer\n          force perf buffers even if ring buffers can be used\n\n  -h, --help\n          Print help (see a summary with '-h')\n""#);
+        insta::assert_yaml_snapshot!(actual, @r#""Usage: lightswitch [OPTIONS] [COMMAND]\n\nCommands:\n  object-info  \n  show-unwind  \n  system-info  \n  help         Print this message or the help of the given subcommand(s)\n\nOptions:\n      --pids <PIDS>\n          Specific PIDs to profile\n\n  -D, --duration <DURATION>\n          How long this agent will run in seconds\n          \n          [default: 18446744073709551615]\n\n      --libbpf-debug\n          Enable libbpf logs. This includes the BPF verifier output\n\n      --bpf-logging\n          Enable BPF programs logging\n\n      --logging <LOGGING>\n          Set lightswitch's logging level\n          \n          [default: info]\n          [possible values: trace, debug, info, warn, error]\n\n      --sample-freq <SAMPLE_FREQ_IN_HZ>\n          Per-CPU Sampling Frequency in Hz\n          \n          [default: 19]\n\n      --profile-format <PROFILE_FORMAT>\n          Output file for Flame Graph in SVG format\n          \n          [default: flame-graph]\n          [possible values: none, flame-graph, pprof]\n\n      --profile-path <PROFILE_PATH>\n          Path for the generated profile\n\n      --profile-name <PROFILE_NAME>\n          Name for the generated profile\n\n      --sender <SENDER>\n          Where to write the profile\n          \n          [default: local-disk]\n\n          Possible values:\n          - none:       Discard the profile. Used for kernel tests\n          - local-disk\n          - remote\n\n      --server-url <SERVER_URL>\n          \n\n      --perf-buffer-bytes <PERF_BUFFER_BYTES>\n          Size of each profiler perf buffer, in bytes (must be a power of 2)\n          \n          [default: 524288]\n\n      --mapsize-info\n          Print eBPF map sizes after creation\n\n      --mapsize-stacks <MAPSIZE_STACKS>\n          max number of individual stacks to capture before aggregation\n          \n          [default: 100000]\n\n      --mapsize-aggregated-stacks <MAPSIZE_AGGREGATED_STACKS>\n          max number of unique stacks after aggregation\n          \n          [default: 10000]\n\n      --mapsize-rate-limits <MAPSIZE_RATE_LIMITS>\n          max number of rate limit entries\n          \n          [default: 5000]\n\n      --exclude-self\n          Do not profile the profiler (myself)\n\n      --symbolizer <SYMBOLIZER>\n          [default: local]\n          [possible values: local, none]\n\n      --debug-info-backend <DEBUG_INFO_BACKEND>\n          [default: none]\n          [possible values: none, copy, remote]\n\n      --max-native-unwind-info-size-mb <MAX_NATIVE_UNWIND_INFO_SIZE_MB>\n          approximate max size in megabytes used for the BPF maps that hold unwind information\n          \n          [default: 2147483647]\n\n      --enable-deadlock-detector\n          enable parking_lot's deadlock detector\n\n      --cache-dir-base <CACHE_DIR_BASE>\n          [default: /tmp]\n\n      --killswitch-path-override <KILLSWITCH_PATH_OVERRIDE>\n          Override the default path to the killswitch file (/tmp/lighswitch/killswitch) which prevents the profiler from starting\n\n      --unsafe-start\n          Force the profiler to start even if the system killswitch is enabled\n\n      --force-perf-buffer\n          force perf buffers even if ring buffers can be used\n\n  -h, --help\n          Print help (see a summary with '-h')\n""#);
     }
 
     #[rstest]


### PR DESCRIPTION
Before they were flags which wasn't ideal, so moving them to subcommands. By default, with no subcommands, the profiler will record samples. In the future this might be moved to its own subcommand.

Additionally, add system and object information to aid debugging.

Test Plan
=========

```
$ cargo run -- object-info /proc/self/exe
- build id: BuildId(sha256-f310b9103919ebdc35cfd63d2f9848c5ee434343943e9a9147f98aa936bc5749)
- executable id: 0xdceb193910b910f3
- unwind info: Ok(())
- go: false
- dynamic: true
- load segments: Ok([ElfLoad { p_offset: 0, p_vaddr: 0, p_filesz: 3231812 }, ElfLoad { p_offset: 3231872, p_vaddr: 3235968, p_filesz: 7370896 }, ElfLoad { p_offset: 10602768, p_vaddr: 10610960, p_filesz: 365712 }, ElfLoad { p_offset: 10968480, p_vaddr: 10980768, p_filesz: 5168 }])

$ cargo run -- system-info
- system info: Ok(SystemInfo { os_release: "6.12.8-100.fc40.x86_64", procfs_mount_detected: true, tracefs_mount_detected: true, tracepoints_support_detected: true, software_perfevents_support_detected: true, available_bpf_features: BpfFeatures { can_load_trivial_bpf_program: true, has_ring_buf: true, has_tail_call: true, has_map_of_maps: true, has_batch_map_operations: true } })
- kernel build id: Ok(BuildId(gnu-0730dd9e6b959a79e0797de379bd078c3792ea98))
- kernel ASLR offset: 0x1b000000
```