### PR TITLE
ci: Add dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Start with GH Actions to get a feel for it, might add cargo deps down the line

Test Plan
=========

CI