### PR TITLE
build: Add rust-src and rust-analyzer

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,12 @@
           devShells.default = mkShell {
             nativeBuildInputs = nativeBuildInputs;
             buildInputs = buildInputs ++ [
-              rust-toolchain
+              (rust-toolchain.override {
+                extensions = [
+                  "rust-src"
+                  "rust-analyzer"
+                ];
+              })
               # Debugging tools
               strace
               gdb


### PR DESCRIPTION
To make sure that the IDE integration that rust-analyzer provides is the same for users of this dev env.

Test Plan
=========

CI