### PR TITLE
Improve error handling dealing with unwind info

### DIFF
--- a/src/bpf/profiler.bpf.c
+++ b/src/bpf/profiler.bpf.c
@@ -192,7 +192,7 @@ find_page(mapping_t *mapping, u64 object_relative_pc, u64 *low_index, u64 *high_
     }
   }
 
-  LOG("[error] could not find page");
+  LOG("[error] could not find page for executable_id: %llx at file_offset: %llx", mapping->executable_id, object_relative_pc);
   bump_unwind_error_chunk_not_found();
   return NULL;
 }

--- a/src/unwind_info/types.rs
+++ b/src/unwind_info/types.rs
@@ -20,7 +20,7 @@ pub enum CfaType {
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub enum RbpType {
     #[default]
-    Unknown = 0,
+    Unchanged = 0,
     CfaOffset = 1,
     Register = 2,
     Expression = 3,
@@ -51,6 +51,16 @@ impl CompactUnwindRow {
             pc: last_addr,
             cfa_type: CfaType::EndFdeMarker,
             ..Default::default()
+        }
+    }
+
+    pub fn frame_setup() -> CompactUnwindRow {
+        CompactUnwindRow {
+            pc: 0,
+            cfa_type: CfaType::FramePointerOffset,
+            rbp_type: RbpType::CfaOffset,
+            cfa_offset: 16,
+            rbp_offset: -16,
         }
     }
 }


### PR DESCRIPTION
This was discovered thanks to
https://github.com/javierhonduco/lightswitch/commit/37a0dc8de23214b9573a1ff5fd3c1bea13043672. Basically the current poor error handling was causing data in BPF maps that should be deleted to be left behind. This surfaced on arm64 as vDSO sections don't have unwind information and this error code path ran.

Test Plan
=========

The test now passes on arm64.