### PR TITLE
crate/object: Make `ExecutableId` a newtype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,6 +1353,7 @@ dependencies = [
  "memmap2 0.9.5",
  "object",
  "ring",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/lightswitch-object/Cargo.toml
+++ b/lightswitch-object/Cargo.toml
@@ -12,3 +12,4 @@ ring = { workspace = true }
 memmap2 = { workspace = true }
 object = { workspace = true }
 anyhow = { workspace = true }
+thiserror = { workspace = true }

--- a/lightswitch-object/src/buildid.rs
+++ b/lightswitch-object/src/buildid.rs
@@ -3,17 +3,58 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::str;
+use std::str::FromStr;
 
 use anyhow::Result;
 use data_encoding::HEXLOWER;
 use ring::digest::Digest;
+
+const MIN_BUILD_ID_BYTES: usize = 8;
 
 /// Compact identifier for executable files.
 ///
 /// Compact identifier for executable files derived from the first 8 bytes
 /// of the build id. By using this smaller type for object files less memory
 /// is used and also comparison, and other operations are cheaper.
-pub type ExecutableId = u64;
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
+pub struct ExecutableId(pub u64);
+
+impl Display for ExecutableId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{:x}", self.0)
+    }
+}
+
+impl From<ExecutableId> for u64 {
+    fn from(executable_id: ExecutableId) -> Self {
+        executable_id.0
+    }
+}
+
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub enum BuildIdError {
+    #[error("expected at least 8 bytes")]
+    TooSmall,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseBuildIdError {
+    #[error("wrong length, must be even")]
+    NotEven,
+    #[error("parsing error")]
+    Parse,
+    #[error("did not fit in the given type")]
+    Fit,
+}
+
+impl FromStr for ExecutableId {
+    type Err = ParseBuildIdError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let id = u64::from_str_radix(s, 16).map_err(|_| ParseBuildIdError::Parse)?;
+        Ok(ExecutableId(id))
+    }
+}
 
 #[derive(Hash, Eq, PartialEq, Clone)]
 pub enum BuildIdFlavour {
@@ -31,30 +72,40 @@ pub struct BuildId {
 }
 
 impl BuildId {
-    pub fn gnu_from_bytes(bytes: &[u8]) -> Self {
-        BuildId {
+    pub fn gnu_from_bytes(bytes: &[u8]) -> Result<Self, BuildIdError> {
+        if bytes.len() < MIN_BUILD_ID_BYTES {
+            return Err(BuildIdError::TooSmall);
+        }
+
+        Ok(BuildId {
             flavour: BuildIdFlavour::Gnu,
             data: bytes.to_vec(),
-        }
+        })
     }
 
-    pub fn go_from_bytes(bytes: &[u8]) -> Self {
-        BuildId {
+    pub fn go_from_bytes(bytes: &[u8]) -> Result<Self, BuildIdError> {
+        if bytes.len() < MIN_BUILD_ID_BYTES {
+            return Err(BuildIdError::TooSmall);
+        }
+
+        Ok(BuildId {
             flavour: BuildIdFlavour::Go,
             data: bytes.to_vec(),
-        }
+        })
     }
 
-    pub fn sha256_from_digest(digest: &Digest) -> Self {
-        BuildId {
+    pub fn sha256_from_digest(digest: &Digest) -> Result<Self, BuildIdError> {
+        Ok(BuildId {
             flavour: BuildIdFlavour::Sha256,
             data: digest.as_ref().to_vec(),
-        }
+        })
     }
 
     /// Returns an identifier for the executable using the first 8 bytes of the build id.
     pub fn id(&self) -> Result<ExecutableId> {
-        Ok(u64::from_ne_bytes(self.data[..8].try_into()?))
+        // We want to interpret these bytes as big endian to have its hexadecimal
+        // representation match.
+        Ok(ExecutableId(u64::from_be_bytes(self.data[..8].try_into()?)))
     }
 
     pub fn short(&self) -> String {
@@ -113,22 +164,55 @@ mod tests {
     use ring::digest::{Context, SHA256};
 
     #[test]
+    fn test_executable_id() {
+        assert_eq!(
+            ExecutableId(0x1020304050607080).to_string(),
+            "1020304050607080"
+        );
+
+        assert_eq!(
+            ExecutableId::from_str("1020304050607080")
+                .unwrap()
+                .to_string(),
+            "1020304050607080"
+        );
+    }
+
+    #[test]
     fn test_buildid() {
         assert_eq!(
-            BuildId::gnu_from_bytes(&[0xbe, 0xef, 0xca, 0xfe]).to_string(),
-            "gnu-beefcafe"
+            BuildId::gnu_from_bytes(&[0xbe]),
+            Err(BuildIdError::TooSmall)
         );
+
+        let gnu =
+            BuildId::gnu_from_bytes(&[0xbe, 0xef, 0xca, 0xfe, 0x01, 0x23, 0x45, 0x67]).unwrap();
+        assert_eq!(gnu.to_string(), "gnu-beefcafe01234567");
+
+        gnu.id().unwrap();
+
         assert_eq!(
-            BuildId::go_from_bytes("fake".as_bytes()).to_string(),
-            "go-fake"
+            BuildId::go_from_bytes("fake1234567".as_bytes())
+                .unwrap()
+                .to_string(),
+            "go-fake1234567"
         );
 
         let mut context = Context::new(&SHA256);
         context.update(&[0xbe, 0xef, 0xca, 0xfe]);
         let digest = context.finish();
         assert_eq!(
-            BuildId::sha256_from_digest(&digest).to_string(),
+            BuildId::sha256_from_digest(&digest).unwrap().to_string(),
             "sha256-b80ad5b1508835ca2191ac800f4bb1a5ae1c3e47f13a8f5ed1b1593337ae5af5"
+        );
+
+        assert_eq!(
+            BuildId::sha256_from_digest(&digest)
+                .unwrap()
+                .id()
+                .unwrap()
+                .0,
+            0xb80ad5b1508835ca
         );
     }
 }

--- a/lightswitch-object/src/kernel.rs
+++ b/lightswitch-object/src/kernel.rs
@@ -31,7 +31,7 @@ pub fn parse_gnu_build_id_from_notes(data: &[u8]) -> Result<BuildId, anyhow::Err
             continue;
         }
 
-        return Ok(BuildId::gnu_from_bytes(note.desc()));
+        return Ok(BuildId::gnu_from_bytes(note.desc())?);
     }
 
     Err(anyhow!("no GNU build id note found"))

--- a/lightswitch-object/src/object.rs
+++ b/lightswitch-object/src/object.rs
@@ -72,14 +72,14 @@ impl ObjectFile {
         let gnu_build_id = object.build_id()?;
 
         if let Some(data) = gnu_build_id {
-            return Ok(BuildId::gnu_from_bytes(data));
+            return Ok(BuildId::gnu_from_bytes(data)?);
         }
 
         // Golang (the Go toolchain does not interpret these bytes as we do).
         for section in object.sections() {
             if section.name()? == ".note.go.buildid" {
                 if let Ok(data) = section.data() {
-                    return Ok(BuildId::go_from_bytes(data));
+                    return Ok(BuildId::go_from_bytes(data)?);
                 }
             }
         }
@@ -88,7 +88,7 @@ impl ObjectFile {
         let Some(code_hash) = code_hash(object) else {
             return Err(anyhow!("code hash is None"));
         };
-        Ok(BuildId::sha256_from_digest(&code_hash))
+        Ok(BuildId::sha256_from_digest(&code_hash)?)
     }
 
     /// Returns whether the object has debug symbols.

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -317,7 +317,7 @@ fn show_object_file_info(path: &str) {
     let object_file = ObjectFile::new(&PathBuf::from(path)).unwrap();
     println!("- build id: {:?}", object_file.build_id());
     if let Ok(executable_id) = object_file.build_id().id() {
-        println!("- executable id: 0x{:x}", executable_id);
+        println!("- executable id: 0x{}", executable_id);
     }
     let unwind_info = CompactUnwindInfoBuilder::with_callback(path, |_| {});
     println!("- unwind info: {:?}", unwind_info.unwrap().process());

--- a/src/process.rs
+++ b/src/process.rs
@@ -236,7 +236,7 @@ mod tests {
         };
 
         let mapping = ExecutableMapping {
-            executable_id: 0x0,
+            executable_id: ExecutableId(0x0),
             build_id: None,
             kind: ExecutableMappingType::FileBacked,
             start_addr: 0x100,

--- a/src/profile/aggregated.rs
+++ b/src/profile/aggregated.rs
@@ -56,7 +56,7 @@ impl RawAggregatedSample {
                 let file_offset = match objs.get(&mapping.executable_id) {
                     Some(obj) => obj.normalized_address(virtual_address, &mapping),
                     None => {
-                        error!("executable with id {} not found", mapping.executable_id);
+                        error!("executable with id 0x{} not found", mapping.executable_id);
                         None
                     }
                 };
@@ -86,7 +86,7 @@ impl RawAggregatedSample {
                 let file_offset = match objs.get(&mapping.executable_id) {
                     Some(obj) => obj.normalized_address(virtual_address, &mapping),
                     None => {
-                        error!("executable with id {} not found", mapping.executable_id);
+                        error!("executable with id 0x{} not found", mapping.executable_id);
                         None
                     }
                 };

--- a/src/profile/convert.rs
+++ b/src/profile/convert.rs
@@ -78,7 +78,7 @@ pub fn to_pprof(
                     }
 
                     let mapping_id = pprof.add_mapping(
-                        mapping.executable_id,
+                        mapping.executable_id.into(),
                         mapping.start_addr,
                         mapping.end_addr,
                         0x0,
@@ -108,7 +108,7 @@ pub fn to_pprof(
                     location_ids.push(location);
                 }
                 None => {
-                    error!("executable with id {} not found", mapping.executable_id);
+                    error!("executable with id 0x{} not found", mapping.executable_id);
                 }
             }
         }
@@ -146,7 +146,7 @@ pub fn to_pprof(
                         None => "no-build-id".into(),
                     };
                     let mapping_id: u64 = pprof.add_mapping(
-                        mapping.executable_id,
+                        mapping.executable_id.into(),
                         mapping.start_addr,
                         mapping.end_addr,
                         mapping.offset,
@@ -176,7 +176,7 @@ pub fn to_pprof(
                     location_ids.push(location);
                 }
                 None => {
-                    debug!("executable with id {} not found", mapping.executable_id);
+                    debug!("executable with id 0x{} not found", mapping.executable_id);
                 }
             }
         }
@@ -345,7 +345,7 @@ pub fn fetch_symbols_for_profile(
                         );
                 }
                 None => {
-                    error!("executable with id {} not found", mapping.executable_id);
+                    error!("executable with id 0x{} not found", mapping.executable_id);
                 }
             }
         }

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -1193,7 +1193,7 @@ impl Profiler {
         for file_offset in page_steps {
             let key = page_key_t {
                 file_offset: file_offset & HIGH_PC_MASK,
-                executable_id,
+                executable_id: executable_id.into(),
             };
 
             let ret = bpf
@@ -1335,7 +1335,7 @@ impl Profiler {
         let res = Self::delete_bpf_unwind_info_map(
             native_unwinder,
             entry.get().bucket_id,
-            mapping.executable_id,
+            mapping.executable_id.into(),
             unwind_info_bucket_usage,
         );
         if res.is_err() {
@@ -1488,7 +1488,7 @@ impl Profiler {
                 load_address,
                 begin: mapping.start_addr,
                 end: mapping.end_addr,
-                executable_id: mapping.executable_id,
+                executable_id: mapping.executable_id.into(),
                 type_: if mapping.kind == ExecutableMappingType::Vdso {
                     MAPPING_TYPE_VDSO
                 } else {
@@ -1502,7 +1502,7 @@ impl Profiler {
                     return;
                 }
                 warn!(
-                    "error adding unwind information for executable {:x} due to {:?}",
+                    "error adding unwind information for executable 0x{} due to {:?}",
                     mapping.executable_id, e
                 );
                 // TODO: maybe cleanup written maps.
@@ -1592,7 +1592,7 @@ impl Profiler {
 
         let inner_map_and_id = Self::create_and_insert_unwind_info_map(
             &mut self.native_unwinder,
-            executable_id,
+            executable_id.into(),
             unwind_info.len(),
             &self.native_unwind_info_bucket_sizes,
             &mut self.native_unwind_state.unwind_info_bucket_usage,
@@ -1605,7 +1605,7 @@ impl Profiler {
                 Self::add_bpf_pages(
                     &self.native_unwinder,
                     &unwind_info,
-                    executable_id,
+                    executable_id.into(),
                     bucket_id,
                 );
                 let unwind_info_start_address = unwind_info.first().unwrap().pc;
@@ -1710,7 +1710,7 @@ impl Profiler {
                 let ret = Self::delete_bpf_unwind_info_map(
                     &mut self.native_unwinder,
                     entry.get().bucket_id,
-                    executable_id,
+                    executable_id.into(),
                     &mut self.native_unwind_state.unwind_info_bucket_usage,
                 );
                 if ret.is_err() {
@@ -1780,7 +1780,7 @@ impl Profiler {
                 }
 
                 warn!(
-                    "error adding unwind information for executable {:x} due to {:?}",
+                    "error adding unwind information for executable 0x{} due to {:?}",
                     executable_id, e
                 );
             }
@@ -1969,7 +1969,7 @@ impl Profiler {
                 }
                 procfs::process::MMapPath::Anonymous => {
                     mappings.push(ExecutableMapping {
-                        executable_id: 0, // Placeholder for JIT.
+                        executable_id: ExecutableId(0), // Placeholder for JIT.
                         build_id: None,
                         kind: ExecutableMappingType::Anonymous,
                         start_addr: map.address.0,


### PR DESCRIPTION
Also implement from_str, fix the bytes to u64 conversion to have both representations look the same, and migrate callsites.

Test Plan
=========
Added unit tests