### PR TITLE
perf-events: Use `std::io::Error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,7 +1283,6 @@ dependencies = [
  "criterion",
  "crossbeam-channel",
  "ctrlc",
- "errno",
  "gimli",
  "glob",
  "inferno",
@@ -1321,7 +1320,6 @@ name = "lightswitch-capabilities"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "errno",
  "glob",
  "libbpf-cargo",
  "libbpf-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ object = "0.36.7"
 libbpf-rs = { version = "0.25.0-beta.1", features = ["static"] }
 tracing = "0.1.41"
 thiserror = "2.0.12"
-errno = "0.3.10"
 perf-event-open-sys = "4.0.0"
 procfs = "0.17.0"
 nix = { version = "0.29.0" }
@@ -58,7 +57,6 @@ libbpf-rs = { workspace = true }
 tracing = { workspace = true }
 perf-event-open-sys = { workspace = true }
 thiserror = { workspace = true }
-errno = { workspace = true }
 procfs = { workspace = true }
 nix = { workspace = true, features = ["user"] }
 parking_lot = { version = "0.12.3", features = ["deadlock_detection"] }

--- a/lightswitch-capabilities/Cargo.toml
+++ b/lightswitch-capabilities/Cargo.toml
@@ -12,7 +12,6 @@ anyhow = { workspace = true}
 thiserror = { workspace = true}
 libbpf-rs = { workspace = true}
 perf-event-open-sys = { workspace = true}
-errno = { workspace = true}
 tracing = { workspace = true}
 nix = { workspace = true, features = ["feature"] }
 

--- a/lightswitch-capabilities/src/system_info.rs
+++ b/lightswitch-capabilities/src/system_info.rs
@@ -10,7 +10,6 @@ use tracing::{error, warn};
 use crate::bpf::features_skel::FeaturesSkelBuilder;
 
 use anyhow::Result;
-use errno::errno;
 use libbpf_rs::skel::{OpenSkel, Skel, SkelBuilder};
 use libc::close;
 use nix::sys::utsname;
@@ -115,7 +114,10 @@ fn software_perfevents_detected() -> bool {
     };
 
     if fd.fd < 0 {
-        error!("setup_perf_event failed with errno {}", errno());
+        error!(
+            "setup_perf_event failed with error {}",
+            std::io::Error::last_os_error()
+        );
         return false;
     }
     true

--- a/src/perf_events.rs
+++ b/src/perf_events.rs
@@ -1,13 +1,11 @@
+use std::io;
 use std::os::raw::c_int;
-
-use anyhow::{anyhow, Result};
-use errno::errno;
 
 use perf_event_open_sys as sys;
 use perf_event_open_sys::bindings::perf_event_attr;
 
 /// # Safety
-pub unsafe fn setup_perf_event(cpu: i32, sample_freq: u64) -> Result<c_int> {
+pub unsafe fn setup_perf_event(cpu: i32, sample_freq: u64) -> Result<c_int, io::Error> {
     let mut attrs: perf_event_attr = perf_event_open_sys::bindings::perf_event_attr {
         size: std::mem::size_of::<sys::bindings::perf_event_attr>() as u32,
         type_: sys::bindings::PERF_TYPE_SOFTWARE,
@@ -25,7 +23,7 @@ pub unsafe fn setup_perf_event(cpu: i32, sample_freq: u64) -> Result<c_int> {
     ) as c_int;
 
     if ret < 0 {
-        return Err(anyhow!("setup_perf_event failed with errno {}", errno()));
+        return Err(io::Error::last_os_error());
     }
 
     Ok(ret)


### PR DESCRIPTION
As it's more natural. `errno` worked great though. They offer a comparison against the stdlib approach:

> No heap allocations
> Optional #![no_std] support
> A set_errno function

https://github.com/lambda-fairy/rust-errno?tab=readme-ov-file#comparison-with-stdioerror

While these features can be very useful in certain environments, the don't offer any substantial benefits to this project.

Test Plan
=========

CI