### PR TITLE
Add support for Go

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,8 +200,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 [[package]]
 name = "blazesym"
 version = "0.2.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d5caf72227115ce486e764e9199d6eab3437c51dacd78c3fae78ca1340c27d"
+source = "git+https://github.com/libbpf/blazesym?rev=94821e3#94821e34cdb601a799ec47f53aca05cd8f77370f"
 dependencies = [
  "cpp_demangle",
  "gimli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,8 @@ lazy_static = "1.5.0"
 plain = "0.2.3"
 page_size = "0.6.0"
 clap = { version = "4.5.32", features = ["derive", "string"] }
-blazesym = "0.2.0-rc.3"
+# See https://github.com/libbpf/blazesym/issues/1105.
+blazesym = { git = "https://github.com/libbpf/blazesym", rev = "94821e3", features = ["zlib"] }
 tracing-subscriber = "0.3.19"
 inferno = "0.12.2"
 primal = "0.3.3"

--- a/lightswitch-object/src/lib.rs
+++ b/lightswitch-object/src/lib.rs
@@ -5,6 +5,8 @@ mod object;
 pub use object::code_hash;
 pub use object::ElfLoad;
 pub use object::ObjectFile;
+pub use object::Runtime;
+pub use object::StopUnwindingFrames;
 
 pub use buildid::BuildId;
 pub use buildid::ExecutableId;

--- a/src/process.rs
+++ b/src/process.rs
@@ -180,7 +180,7 @@ impl ObjectFileInfo {
         let offset = virtual_address - mapping.start_addr + mapping.offset;
 
         for segment in &self.elf_load_segments {
-            let address_range = segment.p_vaddr..(segment.p_vaddr + segment.p_filesz);
+            let address_range = segment.p_offset..(segment.p_offset + segment.p_filesz);
             if address_range.contains(&offset) {
                 return Some(offset - segment.p_offset + segment.p_vaddr);
             }

--- a/src/process.rs
+++ b/src/process.rs
@@ -11,6 +11,7 @@ use tracing::debug;
 use lightswitch_object::BuildId;
 use lightswitch_object::ElfLoad;
 use lightswitch_object::ExecutableId;
+use lightswitch_object::Runtime;
 
 pub type Pid = i32;
 
@@ -122,6 +123,7 @@ pub struct ObjectFileInfo {
     pub references: i64,
     pub native_unwind_info_size: Option<u64>,
     pub is_vdso: bool,
+    pub runtime: Runtime,
 }
 
 impl Clone for ObjectFileInfo {
@@ -134,6 +136,7 @@ impl Clone for ObjectFileInfo {
             references: self.references,
             native_unwind_info_size: self.native_unwind_info_size,
             is_vdso: self.is_vdso,
+            runtime: self.runtime.clone(),
         }
     }
 }
@@ -213,6 +216,7 @@ mod tests {
             references: 1,
             native_unwind_info_size: None,
             is_vdso: false,
+            runtime: Runtime::CLike,
         };
 
         remove_file(file_path).unwrap();
@@ -233,6 +237,7 @@ mod tests {
             references: 0,
             native_unwind_info_size: None,
             is_vdso: false,
+            runtime: Runtime::CLike,
         };
 
         let mapping = ExecutableMapping {

--- a/src/unwind_info/convert.rs
+++ b/src/unwind_info/convert.rs
@@ -238,7 +238,7 @@ pub fn compact_unwind_info(path: &str) -> anyhow::Result<Vec<CompactUnwindRow>> 
                 // Add the end addr when we hit a new func
                 match last_function_end_addr {
                     Some(addr) => {
-                        let marker = CompactUnwindRow::end_of_function_marker(addr);
+                        let marker = CompactUnwindRow::stop_unwinding(addr);
 
                         let row = CompactUnwindRow {
                             pc: marker.pc,
@@ -276,7 +276,7 @@ pub fn compact_unwind_info(path: &str) -> anyhow::Result<Vec<CompactUnwindRow>> 
     }
 
     // Add the last marker
-    let marker = CompactUnwindRow::end_of_function_marker(last_function_end_addr.unwrap());
+    let marker = CompactUnwindRow::stop_unwinding(last_function_end_addr.unwrap());
     unwind_info.push(marker);
 
     // Reduce the unwind information size

--- a/src/unwind_info/optimize.rs
+++ b/src/unwind_info/optimize.rs
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     fn test_remove_unnecesary_markers() {
         let unwind_info = vec![
-            CompactUnwindRow::end_of_function_marker(0x100),
+            CompactUnwindRow::stop_unwinding(0x100),
             CompactUnwindRow {
                 pc: 0x100,
                 ..Default::default()

--- a/src/unwind_info/types.rs
+++ b/src/unwind_info/types.rs
@@ -46,7 +46,7 @@ pub struct CompactUnwindRow {
 }
 
 impl CompactUnwindRow {
-    pub fn end_of_function_marker(last_addr: u64) -> CompactUnwindRow {
+    pub fn stop_unwinding(last_addr: u64) -> CompactUnwindRow {
         CompactUnwindRow {
             pc: last_addr,
             cfa_type: CfaType::EndFdeMarker,
@@ -54,9 +54,9 @@ impl CompactUnwindRow {
         }
     }
 
-    pub fn frame_setup() -> CompactUnwindRow {
+    pub fn frame_setup(pc: u64) -> CompactUnwindRow {
         CompactUnwindRow {
-            pc: 0,
+            pc,
             cfa_type: CfaType::FramePointerOffset,
             rbp_type: RbpType::CfaOffset,
             cfa_offset: 16,

--- a/tests/testprogs/src/go/main.go
+++ b/tests/testprogs/src/go/main.go
@@ -3,20 +3,24 @@ package main
 import "C"
 import "fmt"
 
+//go:noinline
 func top1() {
 	for i := 0; i < 10000; i++ {
 		fmt.Println("top1")
 	}
 }
 
+//go:noinline
 func c1() {
 	top1()
 }
 
+//go:noinline
 func b1() {
 	c1()
 }
 
+//go:noinline
 func a1() {
 	b1()
 }


### PR DESCRIPTION
See commits for this PR, but the summary is:

- added logic to differentiate between runtimes and add unwind
  information
- enabled and pinned our symbolization library
- adapted `to_pages` to support large gaps
- fixed address normalization

Test Plan
=========

CI, will add Go integration tests later on. I've ran manual tests
with the test application as well as tailscaled without any issues.