### PR TITLE
Use `mmap()` to write unwind info and make it 70x faster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,6 +1322,7 @@ dependencies = [
  "glob",
  "libbpf-cargo",
  "libbpf-rs",
+ "libbpf-sys",
  "libc",
  "nix",
  "perf-event-open-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ nix = { version = "0.29.0" }
 libbpf-cargo = { version = "0.25.0-beta.1" }
 glob = "0.3.2"
 ring = "0.17.14"
+libbpf-sys = "1.5.0"
 
 [dependencies]
 gimli = "0.31.1"
@@ -45,7 +46,6 @@ prost = "0.13" # Needed to encode protocol buffers to bytes.
 reqwest = { version = "0.12", features = ["blocking", "rustls-tls"], default-features = false }
 ctrlc = "3.4.5"
 crossbeam-channel = "0.5.14"
-libbpf-sys = "1.5.0"
 itertools = "0.14.0"
 lightswitch-metadata = { path = "lightswitch-metadata", version = "0.2.0" }
 lightswitch-proto = { path = "lightswitch-proto", version = "0.1.0" }
@@ -53,6 +53,7 @@ lightswitch-capabilities = { path = "lightswitch-capabilities", version = "0.1.0
 lightswitch-object = { path = "lightswitch-object", version = "0.2.1" }
 memmap2 = { workspace = true }
 anyhow = { workspace = true }
+libbpf-sys = { workspace = true }
 object = { workspace = true }
 libbpf-rs = { workspace = true }
 tracing = { workspace = true }

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,5 +1,12 @@
 use criterion::{criterion_group, criterion_main, Criterion};
+use itertools::Itertools;
+use libbpf_rs::{MapCore, MapFlags, MapHandle, MapType};
+use lightswitch::bpf::profiler_bindings::stack_unwind_row_t;
 use lightswitch::ksym::KsymIter;
+use lightswitch::unwind_info::types::CompactUnwindRow;
+use lightswitch::util::roundup_page;
+use memmap2::MmapOptions;
+use std::os::fd::AsFd;
 
 pub fn benchmark_kysm_readallkysms(c: &mut Criterion) {
     let mut group = c.benchmark_group("Read /proc/kallsyms");
@@ -10,5 +17,139 @@ pub fn benchmark_kysm_readallkysms(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, benchmark_kysm_readallkysms);
+pub fn update_unwind_info(chunk_size: usize, inner: &MapHandle, unwind_info: &[CompactUnwindRow]) {
+    let chunk_size = std::cmp::min(chunk_size, unwind_info.len());
+    let mut keys: Vec<u8> = Vec::with_capacity(std::mem::size_of::<u32>() * chunk_size);
+    let mut values: Vec<u8> =
+        Vec::with_capacity(std::mem::size_of::<stack_unwind_row_t>() * chunk_size);
+
+    for indices_and_rows in &unwind_info.iter().enumerate().chunks(chunk_size) {
+        keys.clear();
+        values.clear();
+
+        let mut chunk_len = 0;
+
+        for (i, row) in indices_and_rows {
+            let i = i as u32;
+            let row: stack_unwind_row_t = row.into();
+
+            for byte in i.to_le_bytes() {
+                keys.push(byte);
+            }
+            for byte in unsafe { plain::as_bytes(&row) } {
+                values.push(*byte);
+            }
+
+            chunk_len += 1;
+        }
+
+        inner
+            .update_batch(
+                &keys[..],
+                &values[..],
+                chunk_len,
+                MapFlags::ANY,
+                MapFlags::ANY,
+            )
+            .unwrap();
+    }
+}
+
+pub fn benchark_bpf_array(c: &mut Criterion) {
+    let opts = libbpf_sys::bpf_map_create_opts {
+        sz: size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
+        ..Default::default()
+    };
+
+    let opts_mmapable = libbpf_sys::bpf_map_create_opts {
+        sz: size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
+        map_flags: libbpf_sys::BPF_F_MMAPABLE,
+        ..Default::default()
+    };
+
+    let unwind_info = (0..3_000_000)
+        .map(|i| CompactUnwindRow {
+            pc: i,
+            ..Default::default()
+        })
+        .collect::<Vec<CompactUnwindRow>>();
+
+    let inner_map = MapHandle::create(
+        MapType::Array,
+        Some("test_name".to_string()),
+        4,
+        8,
+        unwind_info.len().try_into().unwrap(),
+        &opts,
+    )
+    .unwrap();
+
+    let inner_map_mmapable = MapHandle::create(
+        MapType::Array,
+        Some("test_name".to_string()),
+        4,
+        8,
+        unwind_info.len().try_into().unwrap(),
+        &opts_mmapable,
+    )
+    .unwrap();
+
+    let mut group = c.benchmark_group("BPF array update");
+    group.sample_size(10);
+
+    // Batched updates on map that's not mmapable (so that it's not necessarily page-aligned, as it could
+    // affect benchmarks).
+    group.bench_function("batch of 500k", |b: &mut criterion::Bencher| {
+        b.iter(|| update_unwind_info(500_000, &inner_map, &unwind_info))
+    });
+    group.bench_function("batch of 100k", |b: &mut criterion::Bencher| {
+        b.iter(|| update_unwind_info(100_000, &inner_map, &unwind_info))
+    });
+    group.bench_function("single batch", |b: &mut criterion::Bencher| {
+        b.iter(|| update_unwind_info(unwind_info.len(), &inner_map, &unwind_info))
+    });
+
+    // Batched updates on map that's mmapable, hence page-aligned.
+    group.bench_function(
+        "batch of 500k (opts=mmapable)",
+        |b: &mut criterion::Bencher| {
+            b.iter(|| update_unwind_info(500_000, &inner_map_mmapable, &unwind_info))
+        },
+    );
+    group.bench_function(
+        "batch of 100k (opts=mmapable)",
+        |b: &mut criterion::Bencher| {
+            b.iter(|| update_unwind_info(100_000, &inner_map_mmapable, &unwind_info))
+        },
+    );
+    group.bench_function(
+        "single batch (opts=mmapable)",
+        |b: &mut criterion::Bencher| {
+            b.iter(|| update_unwind_info(unwind_info.len(), &inner_map_mmapable, &unwind_info))
+        },
+    );
+
+    // Using mmap.
+    group.bench_function("mmaped", |b: &mut criterion::Bencher| {
+        b.iter(|| {
+            let size = inner_map_mmapable.value_size() as usize * unwind_info.len();
+            let len = roundup_page(size);
+            let mut mmap = unsafe {
+                MmapOptions::new()
+                    .len(len)
+                    .map_mut(&inner_map_mmapable.as_fd())
+            }
+            .unwrap();
+            let (_prefix, middle, _suffix) = unsafe { mmap.align_to_mut::<stack_unwind_row_t>() };
+
+            for (row, write) in unwind_info.iter().zip(middle) {
+                *write = row.into();
+            }
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, benchark_bpf_array, benchmark_kysm_readallkysms);
 criterion_main!(benches);

--- a/lightswitch-capabilities/Cargo.toml
+++ b/lightswitch-capabilities/Cargo.toml
@@ -14,6 +14,7 @@ libbpf-rs = { workspace = true}
 perf-event-open-sys = { workspace = true}
 tracing = { workspace = true}
 nix = { workspace = true, features = ["feature"] }
+libbpf-sys = { workspace = true }
 
 [build-dependencies]
 libbpf-cargo = { workspace = true}

--- a/lightswitch-capabilities/src/system_info.rs
+++ b/lightswitch-capabilities/src/system_info.rs
@@ -11,6 +11,8 @@ use crate::bpf::features_skel::FeaturesSkelBuilder;
 
 use anyhow::Result;
 use libbpf_rs::skel::{OpenSkel, Skel, SkelBuilder};
+use libbpf_rs::MapHandle;
+use libbpf_rs::MapType;
 use libc::close;
 use nix::sys::utsname;
 use perf_event_open_sys as sys;
@@ -26,6 +28,7 @@ pub struct BpfFeatures {
     pub has_tail_call: bool,
     pub has_map_of_maps: bool,
     pub has_batch_map_operations: bool,
+    pub has_mmapable_bpf_array: bool,
 }
 
 #[derive(Debug)]
@@ -152,6 +155,25 @@ fn tracepoints_detected() -> bool {
     fd.fd >= 0
 }
 
+/// Attempts to create a mmapable BPF array.
+fn has_mmapable_bpf_array() -> bool {
+    let opts = libbpf_sys::bpf_map_create_opts {
+        sz: size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
+        map_flags: libbpf_sys::BPF_F_MMAPABLE,
+        ..Default::default()
+    };
+    let map = MapHandle::create(
+        MapType::Array,
+        Some("unwind_info_test_map".to_string()),
+        4,
+        8,
+        10_000,
+        &opts,
+    );
+
+    map.is_ok()
+}
+
 fn check_bpf_features() -> Result<BpfFeatures> {
     let skel_builder = FeaturesSkelBuilder::default();
     let mut a = MaybeUninit::uninit();
@@ -180,12 +202,13 @@ fn check_bpf_features() -> Result<BpfFeatures> {
         });
     }
 
-    let features: BpfFeatures = BpfFeatures {
+    let features = BpfFeatures {
         can_load_trivial_bpf_program: true,
         has_tail_call: bpf_features_bss.has_tail_call,
         has_ring_buf: bpf_features_bss.has_ringbuf,
         has_map_of_maps: bpf_features_bss.has_map_of_maps,
         has_batch_map_operations: bpf_features_bss.has_batch_map_operations,
+        has_mmapable_bpf_array: has_mmapable_bpf_array(),
     };
 
     Ok(features)

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -112,7 +112,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             return Ok(());
         }
         Some(Commands::SystemInfo) => {
-            println!("- system info: {:?}", SystemInfo::new());
+            println!("- system info: {:#?}", SystemInfo::new());
             println!("- kernel build id: {:?}", kernel_build_id());
             if let Ok(aslr_offset) = kaslr_offset() {
                 println!("- kernel ASLR offset: 0x{:x}", aslr_offset);

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -30,6 +30,7 @@ use libbpf_rs::MapCore;
 use libbpf_rs::MapHandle;
 use libbpf_rs::MapType;
 use libbpf_rs::{Link, MapFlags, PerfBufferBuilder};
+use memmap2::MmapOptions;
 use procfs;
 use tracing::{debug, error, info, span, warn, Level};
 
@@ -52,6 +53,7 @@ use crate::profile::*;
 use crate::unwind_info::manager::UnwindInfoManager;
 use crate::unwind_info::types::CompactUnwindRow;
 use crate::util::executable_path;
+use crate::util::roundup_page;
 use crate::util::Architecture;
 use crate::util::{architecture, get_online_cpus, summarize_address_range};
 use lightswitch_metadata::metadata_provider::{
@@ -286,6 +288,7 @@ impl Profiler {
         {
             let opts = libbpf_sys::bpf_map_create_opts {
                 sz: size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
+                map_flags: libbpf_sys::BPF_F_MMAPABLE,
                 ..Default::default()
             };
             let inner_map_shape = MapHandle::create(
@@ -1125,40 +1128,19 @@ impl Profiler {
     }
 
     fn add_bpf_unwind_info(inner: &MapHandle, unwind_info: &[CompactUnwindRow]) {
-        let chunk_size = std::cmp::min(500_000, unwind_info.len()); // 500k entries fit in 8MB.
-        let mut keys: Vec<u8> = Vec::with_capacity(std::mem::size_of::<u32>() * chunk_size);
-        let mut values: Vec<u8> =
-            Vec::with_capacity(std::mem::size_of::<stack_unwind_row_t>() * chunk_size);
+        let size = inner.value_size() as usize * unwind_info.len();
+        let mut mmap = unsafe {
+            MmapOptions::new()
+                .len(roundup_page(size))
+                .map_mut(&inner.as_fd())
+        }
+        .unwrap();
+        let (prefix, middle, suffix) = unsafe { mmap.align_to_mut::<stack_unwind_row_t>() };
+        assert_eq!(prefix.len(), 0);
+        assert_eq!(suffix.len(), 0);
 
-        for indices_and_rows in &unwind_info.iter().enumerate().chunks(chunk_size) {
-            keys.clear();
-            values.clear();
-
-            let mut chunk_len = 0;
-
-            for (i, row) in indices_and_rows {
-                let i = i as u32;
-                let row: stack_unwind_row_t = row.into();
-
-                for byte in i.to_le_bytes() {
-                    keys.push(byte);
-                }
-                for byte in unsafe { plain::as_bytes(&row) } {
-                    values.push(*byte);
-                }
-
-                chunk_len += 1;
-            }
-
-            inner
-                .update_batch(
-                    &keys[..],
-                    &values[..],
-                    chunk_len,
-                    MapFlags::ANY,
-                    MapFlags::ANY,
-                )
-                .unwrap();
+        for (row, write) in unwind_info.iter().zip(middle) {
+            *write = row.into();
         }
     }
 
@@ -1406,6 +1388,7 @@ impl Profiler {
     ) -> Option<(MapHandle, u32)> {
         let opts = libbpf_sys::bpf_map_create_opts {
             sz: size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
+            map_flags: libbpf_sys::BPF_F_MMAPABLE,
             ..Default::default()
         };
 
@@ -1604,7 +1587,7 @@ impl Profiler {
         let unwind_info = match unwind_info {
             Ok(unwind_info) => unwind_info,
             Err(e) => {
-                let known_naughty = executable_path.contains("libicudata");
+                let known_naughty = executable_path.contains("libicudata.so");
                 if known_naughty {
                     return Err(AddUnwindInformationError::NoUnwindInfoKnownNaughty);
                 } else {

--- a/src/unwind_info/types.rs
+++ b/src/unwind_info/types.rs
@@ -30,7 +30,7 @@ pub enum RbpType {
 
 #[repr(u16)]
 pub enum PltType {
-    // Unknown = 0,
+    Unknown = 0,
     Plt1 = 1,
     Plt2 = 2,
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -2,6 +2,7 @@ mod arch;
 mod cpu;
 mod file;
 mod lpm;
+mod page;
 
 pub use arch::architecture;
 pub use arch::Architecture;
@@ -9,3 +10,4 @@ pub use cpu::get_online_cpus;
 pub use file::executable_path;
 pub use lpm::summarize_address_range;
 pub use lpm::AddressBlockRange;
+pub use page::roundup_page;

--- a/src/util/page.rs
+++ b/src/util/page.rs
@@ -1,0 +1,36 @@
+use std::sync::OnceLock;
+
+use nix::unistd::{sysconf, SysconfVar};
+
+static PAGE_SIZE: OnceLock<usize> = OnceLock::new();
+
+fn roundup(n: usize, round_to: usize) -> usize {
+    n.div_ceil(round_to) * round_to
+}
+
+pub fn roundup_page(n: usize) -> usize {
+    let round_to = PAGE_SIZE.get_or_init(|| {
+        sysconf(SysconfVar::PAGE_SIZE)
+            .expect("error reading page size")
+            .expect("page size is none") as usize
+    });
+    roundup(n, *round_to)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_roundup_page() {
+        roundup_page(0);
+    }
+
+    #[test]
+    fn test_roundup() {
+        assert_eq!(roundup(0, 4096), 0);
+        assert_eq!(roundup(1, 4096), 4096);
+        assert_eq!(roundup(4096, 4096), 4096);
+        assert_eq!(roundup(4097, 4096), 8192);
+    }
+}


### PR DESCRIPTION
This commit changes how unwind information is written to the BPF maps where it's stored. Instead of using batched updates it uses the `BPF_F_MMAPABLE` option introduced in kernel version 5.5 [0], which was released ~5y ago, so it's supported by all the kernels we care about.

Saying that the improvement is "good" would be a significant understatement. It's now 70x faster! Batched BPF updates seem to be way slower than I expected. I couldn't believe the CPU profiles obtained with lightswitch itself, so it wrote some benchmarks and also ran `strace` and `perf trace` to make sure that the numbers made sense.

Note that thanks to using `mmap()` reduces the amount of data buffering. Before this commit, we had to read from disk -> chunks -> bpf maps. Now the intermediate buffer is no longer needed.

Potentially using larger mmap writes would be faster due to `memcpy` having optimizations for large memory copies, but this is so fast right not compared to the previous implementation that I don't think this would be necessary.

The only downside I can think of is that now the allocations that back the BPF arrays need to be page aligned, and in case of larger pages, beyond 4KB there could be some wastage. For the standard page size, this is not really an issue as unwind information can get quite large (dozens of MBs is not unheard of).

Test Plan
=========

## Benchmark comparison

![image](https://github.com/user-attachments/assets/299be34d-348d-4ed3-8299-5c9f5a9de387)

## Batched update with single batch to minimise syscall overhead

<img width="932" alt="image" src="https://github.com/user-attachments/assets/886fb5c1-bf5c-4cbc-9db7-dba280911a65" />

## mmaped version

<img width="932" alt="image" src="https://github.com/user-attachments/assets/59580efb-8de0-4e3a-9d11-425ad81373e4" />



- [0]: https://github.com/torvalds/linux/commit/fc9702273e2edb90400a34b3be76f7b08fa3344b