### PR TITLE
Use `bpf_task_pt_regs` if available

### DIFF
--- a/lightswitch-capabilities/src/bpf/features.bpf.c
+++ b/lightswitch-capabilities/src/bpf/features.bpf.c
@@ -11,6 +11,7 @@ bool has_tail_call = false;
 bool has_ringbuf = false;
 bool has_map_of_maps = false;
 bool has_batch_map_operations = false;
+bool has_task_pt_regs_helper = false;
 
 SEC("tracepoint/sched/sched_switch")
 int detect_bpf_features(void *ctx) {
@@ -22,9 +23,12 @@ int detect_bpf_features(void *ctx) {
 
     has_map_of_maps = bpf_core_enum_value_exists(
         enum bpf_map_type, BPF_MAP_TYPE_HASH_OF_MAPS);
-    
+
     has_batch_map_operations = bpf_core_enum_value_exists(
         enum bpf_cmd, BPF_MAP_LOOKUP_AND_DELETE_BATCH);
+
+    has_task_pt_regs_helper = bpf_core_enum_value_exists(
+        enum bpf_func_id, BPF_FUNC_task_pt_regs);
 
     feature_check_done = true;
 

--- a/lightswitch-capabilities/src/system_info.rs
+++ b/lightswitch-capabilities/src/system_info.rs
@@ -29,6 +29,7 @@ pub struct BpfFeatures {
     pub has_map_of_maps: bool,
     pub has_batch_map_operations: bool,
     pub has_mmapable_bpf_array: bool,
+    pub has_task_pt_regs_helper: bool,
 }
 
 #[derive(Debug)]
@@ -209,6 +210,7 @@ fn check_bpf_features() -> Result<BpfFeatures> {
         has_map_of_maps: bpf_features_bss.has_map_of_maps,
         has_batch_map_operations: bpf_features_bss.has_batch_map_operations,
         has_mmapable_bpf_array: has_mmapable_bpf_array(),
+        has_task_pt_regs_helper: bpf_features_bss.has_task_pt_regs_helper,
     };
 
     Ok(features)

--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -88,6 +88,7 @@ typedef struct {
 struct lightswitch_config_t {
   bool verbose_logging;
   bool use_ring_buffers;
+  bool use_task_pt_regs_helper;
 };
 
 struct unwinder_stats_t {
@@ -116,6 +117,7 @@ struct unwinder_stats_t {
 const volatile struct lightswitch_config_t lightswitch_config = {
     .verbose_logging = false,
     .use_ring_buffers = false,
+    .use_task_pt_regs_helper = false,
 };
 
 // A different stack produced the same hash.

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -199,6 +199,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         debug_info_manager,
         max_native_unwind_info_size_mb: args.max_native_unwind_info_size_mb,
         use_ring_buffers,
+        use_task_pt_regs_helper: system_info.available_bpf_features.has_task_pt_regs_helper,
         ..Default::default()
     };
 

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -171,6 +171,7 @@ pub struct ProfilerConfig {
     pub debug_info_manager: Box<dyn DebugInfoManager>,
     pub max_native_unwind_info_size_mb: i32,
     pub use_ring_buffers: bool,
+    pub use_task_pt_regs_helper: bool,
 }
 
 impl Default for ProfilerConfig {
@@ -195,6 +196,7 @@ impl Default for ProfilerConfig {
             debug_info_manager: Box::new(DebugInfoBackendNull {}),
             max_native_unwind_info_size_mb: i32::MAX,
             use_ring_buffers: true,
+            use_task_pt_regs_helper: true,
         }
     }
 }


### PR DESCRIPTION
In kernel context (syscalls, interrupts, etc) the unwinder has to do additional work to fish out the userspace registers. We do this by replicating the logic in the kernel by hand. This works fine, but unfortunately there's been some ABI changes [0]. Rather than adjusting it and have to keep it in sync, use the `bpf_task_pt_regs` helper to do this.

It was added in 2021 and the ABI changes are more recent, so keeping the current logic when the helper is not available as is.

- [0]: https://github.com/javierhonduco/lightswitch/issues/204