### PR TITLE
[Refactor] Create RawSample struct

### DIFF
--- a/src/profile/convert.rs
+++ b/src/profile/convert.rs
@@ -16,7 +16,7 @@ use crate::ksym::Ksym;
 use crate::ksym::KsymIter;
 use crate::process::ObjectFileInfo;
 use crate::process::ProcessInfo;
-use crate::profile::aggregated::RawAggregatedProfile;
+use crate::profile::sample::RawAggregatedProfile;
 use crate::profile::{AggregatedProfile, AggregatedSample, Frame, FrameAddress};
 use crate::usym::symbolize_native_stack_blaze;
 use lightswitch_object::ExecutableId;

--- a/src/profile/convert.rs
+++ b/src/profile/convert.rs
@@ -16,8 +16,9 @@ use crate::ksym::Ksym;
 use crate::ksym::KsymIter;
 use crate::process::ObjectFileInfo;
 use crate::process::ProcessInfo;
-use crate::profile::sample::RawAggregatedProfile;
-use crate::profile::{AggregatedProfile, AggregatedSample, Frame, FrameAddress};
+use crate::profile::{
+    AggregatedProfile, AggregatedSample, Frame, FrameAddress, RawAggregatedProfile,
+};
 use crate::usym::symbolize_native_stack_blaze;
 use lightswitch_object::ExecutableId;
 

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -1,7 +1,7 @@
-mod aggregated;
 mod convert;
 mod frame;
+mod sample;
 
-pub use aggregated::*;
 pub use convert::*;
 pub use frame::*;
+pub use sample::*;

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -937,12 +937,12 @@ impl Profiler {
     }
 
     /// Updates the last time processes and executables were seen. This is used during evictions.
-    pub fn bump_last_used(&mut self, raw_samples: &[RawAggregatedSample]) {
+    pub fn bump_last_used(&mut self, raw_aggregated_samples: &[RawAggregatedSample]) {
         let now = Instant::now();
 
-        for raw_sample in raw_samples {
-            let pid = raw_sample.pid;
-            let ustack = raw_sample.ustack;
+        for aggregated_sample in raw_aggregated_samples {
+            let pid = aggregated_sample.sample.pid;
+            let ustack = aggregated_sample.sample.ustack;
             let Some(ustack) = ustack else {
                 continue;
             };
@@ -1103,14 +1103,16 @@ impl Profiler {
                         }
                     }
 
-                    let raw_sample = RawAggregatedSample {
-                        pid: key.pid,
-                        tid: key.task_id,
-                        ustack: result_ustack,
-                        kstack: result_kstack,
+                    let raw_aggregated_sample = RawAggregatedSample {
+                        sample: RawSample {
+                            pid: key.pid,
+                            tid: key.task_id,
+                            ustack: result_ustack,
+                            kstack: result_kstack,
+                        },
                         count: *count,
                     };
-                    result.push(raw_sample);
+                    result.push(raw_aggregated_sample);
                 }
                 _ => continue,
             }


### PR DESCRIPTION
#### Context
* In a future diff, bpf will send unaggregated samples to userspace. The current plan is to store those unaggregated samples and eventually have the collector aggregate or decide what to do with them.

#### Changes
* Create a new `RawSample` struct to hold the raw unaggregated samples.
* Refactor `RawAggregatedSample` to use this inner struct.

#### Test Plan
* Existing CI checks
* No behaviour changes expected