### PR TITLE
Update Cargo hash

### DIFF
--- a/vm.nix
+++ b/vm.nix
@@ -135,6 +135,7 @@ let
       rev = "51f11bf301fea054342996802a16ed21fb5054f4";
       sha256 = "sha256-qtTq0dnDHi1ITfQzKrXz+1dRMymAFBivWpjXntD09+A=";
     };
+    useFetchCargoVendor = true;
     cargoHash = "sha256-HLpb4l2LoYdC3k7NH5DRqd9zXqQ/2w6nkUKLGiAsR28=";
     # nativeCheckInputs = [ pkgs.qemu ];
 

--- a/vm.nix
+++ b/vm.nix
@@ -135,7 +135,6 @@ let
       rev = "51f11bf301fea054342996802a16ed21fb5054f4";
       sha256 = "sha256-qtTq0dnDHi1ITfQzKrXz+1dRMymAFBivWpjXntD09+A=";
     };
-    useFetchCargoVendor = true;
     cargoHash = "sha256-HLpb4l2LoYdC3k7NH5DRqd9zXqQ/2w6nkUKLGiAsR28=";
     # nativeCheckInputs = [ pkgs.qemu ];
 

--- a/vm.nix
+++ b/vm.nix
@@ -135,7 +135,7 @@ let
       rev = "51f11bf301fea054342996802a16ed21fb5054f4";
       sha256 = "sha256-qtTq0dnDHi1ITfQzKrXz+1dRMymAFBivWpjXntD09+A=";
     };
-    cargoHash = "sha256-SHjjCWz4FVVk1cczkMltRVEB3GK8jz2tVABNSlSZiUc=";
+    cargoHash = "sha256-HLpb4l2LoYdC3k7NH5DRqd9zXqQ/2w6nkUKLGiAsR28=";
     # nativeCheckInputs = [ pkgs.qemu ];
 
     # There are some errors trying to access `/build/source/tests/*`.


### PR DESCRIPTION
#### Context
* When I run `nix rum .#vmtest`, I see
```
evaluation warning: rustPlatform.fetchCargoTarball is deprecated in favor of rustPlatform.fetchCargoVendor.
                    If you are using buildRustPackage, try setting useFetchCargoVendor = true and regenerating cargoHash.
                    See the 25.05 release notes for more information.
error: hash mismatch in fixed-output derivation '/nix/store/1v4dv99bn9daqyajqji17x0jj19m496q-vmtest-vendor.tar.gz.drv':
         specified: sha256-SHjjCWz4FVVk1cczkMltRVEB3GK8jz2tVABNSlSZiUc=
            got:    sha256-HLpb4l2LoYdC3k7NH5DRqd9zXqQ/2w6nkUKLGiAsR28=
```
* This appears to fix the build error in #219 


#### Changes
* Update the nix CargoHash