### PR TITLE
Do not keep a reference to executables

### DIFF
--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -320,7 +320,7 @@ fn show_unwind_info(path: &str) {
 }
 
 fn show_object_file_info(path: &str) {
-    let object_file = ObjectFile::new(&PathBuf::from(path)).unwrap();
+    let object_file = ObjectFile::from_path(&PathBuf::from(path)).unwrap();
     println!("- build id: {:?}", object_file.build_id());
     if let Ok(executable_id) = object_file.build_id().id() {
         println!("- executable id: 0x{}", executable_id);


### PR DESCRIPTION
This features was intended to reduce race condition windows when a file system is unmounted or an executable is deleted for some reason. The benefits are dubious and it can be quite problematic when running in continuous mode. The kernel won't remove files until they are no longer referenced and we'll keep the last reference for the whole execution of the profiler. In constrained environments this can result in files not being removed, for example, if many new versions of an executable are released but never removed this can fill up the file system.

Future work: pass the opened file to the unwind information manager as well to increase the chances of successfully parsing and converting its unwind info.

Test Plan
=========

CI