### PR TITLE
build: Expose static C++ musl binary

### DIFF
--- a/tests/testprogs/flake.nix
+++ b/tests/testprogs/flake.nix
@@ -160,6 +160,7 @@
             cpp-progs = test-cpp-progs;
             go-progs = test-go-progs;
             cgo-progs = test-cgo-progs;
+            cpp-progs-static-musl = test-static-musl-cpp-progs;
           };
         }
       );


### PR DESCRIPTION
Test Plan
=========

```
(nix:nix-shell-env) [javierhonduco@fedora lightswitch]$ pushd tests/testprogs/
~/src/lightswitch/tests/testprogs ~/src/lightswitch
(nix:nix-shell-env) [javierhonduco@fedora testprogs]$ nix build .#cpp-progs-static-musl
(nix:nix-shell-env) [javierhonduco@fedora testprogs]$ ldd ./result/bin/main_cpp_clang_static_musl_O3
        not a dynamic executable
```