### PR TITLE
Fully support Zig

### DIFF
--- a/lightswitch-object/src/lib.rs
+++ b/lightswitch-object/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(let_chains)]
 mod buildid;
 pub mod kernel;
 mod object;

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -303,7 +303,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 fn show_unwind_info(path: &str) {
-    let unwind_info = compact_unwind_info(path).unwrap();
+    let unwind_info = compact_unwind_info(path, None).unwrap();
     for compact_row in unwind_info {
         let pc = compact_row.pc;
         let cfa_type = compact_row.cfa_type;
@@ -323,7 +323,7 @@ fn show_object_file_info(path: &str) {
     if let Ok(executable_id) = object_file.build_id().id() {
         println!("- executable id: 0x{executable_id}");
     }
-    let unwind_info = CompactUnwindInfoBuilder::with_callback(path, |_| {});
+    let unwind_info = CompactUnwindInfoBuilder::with_callback(path, None, |_| {});
     println!("- unwind info: {:?}", unwind_info.unwrap().process());
     println!("- go: {:?}", object_file.is_go());
     println!("- dynamic: {:?}", object_file.is_dynamic());

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -1577,6 +1577,23 @@ impl Profiler {
                 unwind_info.sort_by_key(|e| e.pc);
                 Ok(unwind_info)
             }
+            Runtime::Zig {
+                start_low_address,
+                start_high_address,
+            } => {
+                let _span = span!(
+                    Level::DEBUG,
+                    "calling in_memory_unwind_info",
+                    "{}",
+                    executable_path.display()
+                )
+                .entered();
+                self.unwind_info_manager.fetch_unwind_info(
+                    &executable_path,
+                    executable_id,
+                    Some((start_low_address, start_high_address)),
+                )
+            }
             Runtime::CLike => {
                 if needs_synthesis {
                     debug!("synthetising arm64 unwind information using frame pointers for vDSO");
@@ -1592,8 +1609,11 @@ impl Profiler {
                         executable_path.display()
                     )
                     .entered();
-                    self.unwind_info_manager
-                        .fetch_unwind_info(&executable_path, executable_id)
+                    self.unwind_info_manager.fetch_unwind_info(
+                        &executable_path,
+                        executable_id,
+                        None,
+                    )
                 }
             }
         };


### PR DESCRIPTION
While profiling a Zig workload
(https://matklad.github.io/2025/05/06/performance-profile-visualization-challenge.html) unwinding catastrophically fails, this is due to a couple of issues documented on https://github.com/javierhonduco/lightswitch/issues/264. This commit focuses on adding support for Zig executables compiled with the Zig compiler before commit [130f7c2ed8e3358e24bb2fc7cca57f7a6f1f85c3](https://github.com/ziglang/zig/commit/130f7c2ed8e3358e24bb2fc7cca57f7a6f1f85c3) as the first function, `start` did not have the right DWARF unwind information.

In order to remediate this on our side, we attempt to recognise Zig binaries with simple symbol-based heuristics, as there is no metadata of any kind in the ELF files that we could use to know whether it was compiled with the Zig compiler and if the version used contains this bug.

The address range for the first function is read and the right unwind information is then overriden for this file offset. We can't tell if the compiler used has the bug or not until we aren't processing the unwind information and given that all this is cached, the additional work of always having traversing the symbol table is not a problem. I've verified that this is the case with some self-profiles.

Notes
=====

- This is not enough to be able to successfully profile Tigerbeetle, more PRs coming, see issue and "Test Plan" there;
- The persisted unwind information for Zig should be reset. Will update the version in another PR as https://github.com/javierhonduco/lightswitch/issues/266 needs a version bump too