### PR TITLE
Fix load address calculation

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -49,7 +49,6 @@ pub struct ExecutableMapping {
     // kaslr info etc etc
     pub offset: u64,
     pub load_address: u64,
-    pub main_exec: bool,
     pub soft_delete: bool,
 }
 
@@ -185,7 +184,6 @@ mod tests {
             end_addr: 0x100 + 100,
             offset: 0x0,
             load_address: 0x0,
-            main_exec: false,
             soft_delete: false,
         };
 


### PR DESCRIPTION
This is how libunwind does it: https://github.com/libunwind/libunwind/blob/2a15c30f7e72c34bbf925c555e9546e4fa25ec01/src/elfxx.c#L428 and how the kernel actually maps the LOAD segments https://github.com/torvalds/linux/blob/0ff41df1cb268fc69e703a08a57ee14ae967d0ca/fs/binfmt_elf.c#L369C9-L369C22

Test Plan
=========
This fixes unwinding in various applications, such as statically compiled Zig binaries.