### PR TITLE
Skip digest checks when reading unwind info

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -1592,6 +1592,7 @@ impl Profiler {
                     &executable_path,
                     executable_id,
                     Some((start_low_address, start_high_address)),
+                    false,
                 )
             }
             Runtime::CLike => {
@@ -1613,6 +1614,7 @@ impl Profiler {
                         &executable_path,
                         executable_id,
                         None,
+                        false,
                     )
                 }
             }


### PR DESCRIPTION
This check was put in place to make sure we aren't loading corrupted unwind information. This is an unlikely thing to happen but we are paying a high cost, especially in memory-constrained environments as unwind information will be evicted and re-read from disk with the consequent digest checks.

Keeping the digest is very useful for debugging purposes, but checking it on every read is not worth it performance wise, right now in some of my tests, 50% of lightswitch's CPU time is spent computing the digest.

Some of the future things that could be done:
- switching to a faster hash algorithm and optimise the buffer sizes
- check a small % of reads

Test Plan
=========
CI