### PR TITLE
Do not clone mapping in `for_address`

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -57,14 +57,10 @@ pub struct ExecutableMappings(pub Vec<ExecutableMapping>);
 
 impl ExecutableMappings {
     /// Find the executable mapping a given virtual address falls into.
-    pub fn for_address(&self, virtual_address: u64) -> Option<ExecutableMapping> {
-        for mapping in &self.0 {
-            if (mapping.start_addr..mapping.end_addr).contains(&virtual_address) {
-                return Some(mapping.clone());
-            }
-        }
-
-        None
+    pub fn for_address(&self, virtual_address: u64) -> Option<&ExecutableMapping> {
+        self.0
+            .iter()
+            .find(|&mapping| (mapping.start_addr..mapping.end_addr).contains(&virtual_address))
     }
 }
 

--- a/src/profile/convert.rs
+++ b/src/profile/convert.rs
@@ -71,7 +71,7 @@ pub fn to_pprof(
                 Some(obj) => {
                     let normalized_addr = kframe
                         .file_offset
-                        .or_else(|| obj.normalized_address(virtual_address, &mapping));
+                        .or_else(|| obj.normalized_address(virtual_address, mapping));
 
                     if normalized_addr.is_none() {
                         debug!("normalized address is none");
@@ -86,6 +86,7 @@ pub fn to_pprof(
                         obj.path.to_str().expect("will always be valid"), // should this be named name?,
                         &mapping
                             .build_id
+                            .as_ref()
                             .expect("this should never happen")
                             .to_string(),
                     );
@@ -133,7 +134,7 @@ pub fn to_pprof(
                 Some(obj) => {
                     let normalized_addr = uframe
                         .file_offset
-                        .or_else(|| obj.normalized_address(virtual_address, &mapping));
+                        .or_else(|| obj.normalized_address(virtual_address, mapping));
 
                     if normalized_addr.is_none() {
                         debug!("normalized address is none");
@@ -142,7 +143,7 @@ pub fn to_pprof(
 
                     let normalized_addr = normalized_addr.unwrap();
 
-                    let build_id = match mapping.build_id {
+                    let build_id = match &mapping.build_id {
                         Some(build_id) => {
                             format!("{build_id}")
                         }

--- a/src/profile/sample.rs
+++ b/src/profile/sample.rs
@@ -99,7 +99,7 @@ impl RawAggregatedSample {
                 };
 
                 let file_offset = match objs.get(&mapping.executable_id) {
-                    Some(obj) => obj.normalized_address(virtual_address, &mapping),
+                    Some(obj) => obj.normalized_address(virtual_address, mapping),
                     None => {
                         error!("executable with id 0x{} not found", mapping.executable_id);
                         None
@@ -129,7 +129,7 @@ impl RawAggregatedSample {
                 };
 
                 let file_offset = match objs.get(&mapping.executable_id) {
-                    Some(obj) => obj.normalized_address(virtual_address, &mapping),
+                    Some(obj) => obj.normalized_address(virtual_address, mapping),
                     None => {
                         error!("executable with id 0x{} not found", mapping.executable_id);
                         None


### PR DESCRIPTION
This code path showed up during self-profiling. It wasn't a bit hostpot but the fix is easy enough :)

Test Plan
=========

CI