### PR TITLE
Store unwind info in dynamically sized inner maps

### DIFF
--- a/lightswitch-capabilities/src/system_info.rs
+++ b/lightswitch-capabilities/src/system_info.rs
@@ -296,6 +296,9 @@ impl SystemInfo {
             && self.tracepoints_support_detected
             && bpf_features.can_load_trivial_bpf_program
             && bpf_features.has_tail_call
+            && bpf_features.has_map_of_maps
+            && bpf_features.has_mmapable_bpf_array
+            && bpf_features.has_variable_inner_map
     }
 }
 

--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -20,8 +20,8 @@ _Static_assert(MAX_TAIL_CALLS *MAX_STACK_DEPTH_PER_PROGRAM >= MAX_STACK_DEPTH,
 #define MAX_MAPPINGS MAX_PROCESSES * 200
 // Binary search iterations to find unwind information.
 #define MAX_BINARY_SEARCH_DEPTH 17
-// Number of entries in the outer unwind map.
-#define MAX_OUTER_UNWIND_MAP_ENTRIES 500
+// Number of entries in the 'outer' unwind map.
+#define MAX_OUTER_UNWIND_MAP_ENTRIES 3000
 
 #define UNWIND_INFO_PAGE_BIT_LEN 16
 #define UNWIND_INFO_PAGE_SIZE (1 << UNWIND_INFO_PAGE_BIT_LEN)
@@ -45,7 +45,6 @@ typedef struct {
 } page_key_t;
 
 typedef struct {
-  u32 bucket_id;
   u32 low_index;
   u32 high_index;
 } page_value_t;


### PR DESCRIPTION
In commit 4a8f87e (5.10), the kernel added support for dynamically sized inner maps. This means that we can remove the current bucketing which results in a large space wastage.

Test Plan
=========

Ran for a couple of hours with no issues.

- https://github.com/torvalds/linux/commit/4a8f87e60f6db40e640f1db555d063b2c4dea5f1