### PR TITLE
Send the minimum amount of data for a sample

### DIFF
--- a/src/aggregator.rs
+++ b/src/aggregator.rs
@@ -16,7 +16,7 @@ impl Aggregator {
 
         let mut sample_hash_to_aggregated: HashMap<u64, RawAggregatedSample> = HashMap::new();
         for sample in raw_samples {
-            if sample.ustack.is_none() & sample.kstack.is_none() {
+            if sample.ustack.is_empty() && sample.kstack.is_empty() {
                 warn!(
                     "No stack present in provided sample={}, skipping...",
                     sample
@@ -40,64 +40,33 @@ impl Aggregator {
 #[cfg(test)]
 mod tests {
     use crate::aggregator::Aggregator;
-    use crate::bpf::profiler_bindings::native_stack_t;
     use crate::profile::RawSample;
 
     #[test]
     fn test_aggregate_raw_samples() {
-        // Given
-        let mut ustack1_data = [0; 127];
-        ustack1_data[0] = 0xffff;
-        ustack1_data[1] = 0xdeadbeef;
-        let ustack1 = Some(native_stack_t {
-            addresses: ustack1_data,
-            len: 2,
-        });
-
-        let mut kstack1_data = [0; 127];
-        kstack1_data[0] = 0xffff;
-        kstack1_data[1] = 0xdddd;
-        kstack1_data[2] = 0xaaaa;
-        kstack1_data[3] = 0xeeee;
-        kstack1_data[4] = 0xaaae;
-        let kstack1 = Some(native_stack_t {
-            addresses: kstack1_data,
-            len: 5,
-        });
-
         let raw_sample_1 = RawSample {
             pid: 1234,
             tid: 1235,
             collected_at: 1748865070,
-            ustack: ustack1,
-            kstack: kstack1,
+            ustack: vec![0xffff, 0xffff],
+            kstack: vec![0xffff, 0xdddd, 0xaaaa, 0xeeee, 0xaaae],
         };
-
-        let mut ustack2_data = [0; 127];
-        ustack2_data[0] = 0xdddd;
-        ustack2_data[1] = 0xfeedbee;
-        ustack2_data[0] = 0xddddef;
-        ustack2_data[1] = 0xbeefdad;
-        let ustack2 = Some(native_stack_t {
-            addresses: ustack2_data,
-            len: 4,
-        });
 
         let raw_sample_2 = RawSample {
             pid: 1234,
             tid: 1235,
             collected_at: 1748865070,
-            ustack: ustack2,
-            kstack: None,
+            ustack: vec![0xdddd, 0xfeedbee, 0xddddef, 0xbeefdad],
+            kstack: vec![],
         };
 
         let raw_samples = vec![
-            raw_sample_1,
-            raw_sample_2,
-            raw_sample_1,
-            raw_sample_2,
-            raw_sample_2,
-            raw_sample_2,
+            raw_sample_1.clone(),
+            raw_sample_2.clone(),
+            raw_sample_1.clone(),
+            raw_sample_2.clone(),
+            raw_sample_2.clone(),
+            raw_sample_2.clone(),
         ];
 
         let aggregator = Aggregator::default();
@@ -118,42 +87,27 @@ mod tests {
 
     #[test]
     fn test_aggregate_raw_samples_same_ustack_diff_kstack() {
-        let mut ustack_data = [0; 127];
-        ustack_data[0] = 0xffff;
-        ustack_data[1] = 0xdeadbeef;
-        let ustack = Some(native_stack_t {
-            addresses: ustack_data,
-            len: 2,
-        });
-
-        let mut kstack1_data = [0; 127];
-        kstack1_data[0] = 0xffff;
-        kstack1_data[1] = 0xdddd;
-        kstack1_data[2] = 0xaaaa;
-        kstack1_data[3] = 0xeeee;
-        kstack1_data[4] = 0xaaae;
-        let kstack1 = Some(native_stack_t {
-            addresses: kstack1_data,
-            len: 5,
-        });
-
         let raw_sample_1 = RawSample {
             pid: 1234,
             tid: 1235,
             collected_at: 1748865070,
-            ustack,
-            kstack: kstack1,
+            ustack: vec![0xffff, 0xdeadbeef],
+            kstack: vec![0xffff, 0xdddd, 0xaaaa, 0xeeee, 0xaaae],
         };
 
         let raw_sample_2 = RawSample {
             pid: 1234,
             tid: 1235,
             collected_at: 1748865070,
-            ustack,
-            kstack: None,
+            ustack: raw_sample_1.ustack.clone(),
+            kstack: vec![],
         };
 
-        let raw_samples = vec![raw_sample_1, raw_sample_2, raw_sample_2];
+        let raw_samples = vec![
+            raw_sample_1.clone(),
+            raw_sample_2.clone(),
+            raw_sample_2.clone(),
+        ];
 
         let aggregator = Aggregator::default();
 
@@ -173,57 +127,28 @@ mod tests {
 
     #[test]
     fn test_aggregate_raw_samples_diff_ustack_same_kstack() {
-        let mut ustack1_data = [0; 127];
-        ustack1_data[0] = 0xffff;
-        ustack1_data[1] = 0xdeadbeef;
-        let ustack1 = Some(native_stack_t {
-            addresses: ustack1_data,
-            len: 2,
-        });
-
-        let mut kstack1_data = [0; 127];
-        kstack1_data[0] = 0xffff;
-        kstack1_data[1] = 0xdddd;
-        kstack1_data[2] = 0xaaaa;
-        kstack1_data[3] = 0xeeee;
-        kstack1_data[4] = 0xaaae;
-        let kstack1 = Some(native_stack_t {
-            addresses: kstack1_data,
-            len: 5,
-        });
-
         let raw_sample_1 = RawSample {
             pid: 1234,
             tid: 1235,
             collected_at: 1748865070,
-            ustack: ustack1,
-            kstack: kstack1,
+            ustack: vec![0xffff, 0xdeadbeef],
+            kstack: vec![0xffff, 0xdddd, 0xaaaa, 0xeeee, 0xaaae],
         };
-
-        let mut ustack2_data = [0; 127];
-        ustack2_data[0] = 0xdddd;
-        ustack2_data[1] = 0xfeedbee;
-        ustack2_data[0] = 0xddddef;
-        ustack2_data[1] = 0xbeefdad;
-        let ustack2 = Some(native_stack_t {
-            addresses: ustack2_data,
-            len: 4,
-        });
 
         let raw_sample_2 = RawSample {
             pid: 1234,
             tid: 1235,
             collected_at: 1748865070,
-            ustack: ustack2,
-            kstack: kstack1,
+            ustack: vec![0xdddd, 0xfeedbee, 0xddddef, 0xbeefdad],
+            kstack: raw_sample_1.kstack.clone(),
         };
 
         let raw_samples = vec![
-            raw_sample_1,
-            raw_sample_2,
-            raw_sample_1,
-            raw_sample_2,
-            raw_sample_1,
+            raw_sample_1.clone(),
+            raw_sample_2.clone(),
+            raw_sample_1.clone(),
+            raw_sample_2.clone(),
+            raw_sample_1.clone(),
         ];
 
         let aggregator = Aggregator::default();
@@ -244,45 +169,31 @@ mod tests {
 
     #[test]
     fn test_aggregate_same_stack_traces_different_pid_tid() {
-        let mut ustack_data = [0; 127];
-        ustack_data[0] = 0xffff;
-        ustack_data[1] = 0xdeadbeef;
-        let ustack = Some(native_stack_t {
-            addresses: ustack_data,
-            len: 2,
-        });
-
-        let mut kstack_data = [0; 127];
-        kstack_data[0] = 0xffff;
-        kstack_data[1] = 0xdddd;
-        kstack_data[2] = 0xaaaa;
-        let kstack = Some(native_stack_t {
-            addresses: kstack_data,
-            len: 5,
-        });
+        let ustack = vec![0xffff, 0xdeadbeef];
+        let kstack = vec![0xffff, 0xdddd, 0xaaaa];
 
         let raw_sample_1 = RawSample {
             pid: 1234,
             tid: 1235,
             collected_at: 1748865070,
-            ustack,
-            kstack,
+            ustack: ustack.clone(),
+            kstack: kstack.clone(),
         };
 
         let raw_sample_2 = RawSample {
             pid: 1234,
             tid: 1236,
             collected_at: 1748865070,
-            ustack,
-            kstack,
+            ustack: ustack.clone(),
+            kstack: kstack.clone(),
         };
 
         let raw_sample_3 = RawSample {
             pid: 123,
             tid: 124,
             collected_at: 1748865070,
-            ustack,
-            kstack,
+            ustack: ustack.clone(),
+            kstack: kstack.clone(),
         };
 
         let raw_samples = vec![raw_sample_1, raw_sample_2, raw_sample_3];

--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -149,34 +149,32 @@ typedef struct __attribute__((packed)) {
 _Static_assert(sizeof(stack_unwind_row_t) == 8,
                "unwind row has the expected size");
 
+
+
 // The addresses of a native stack trace.
 typedef struct {
-  u64 len;
-  u64 addresses[MAX_STACK_DEPTH];
+  u32 ulen;
+  u32 klen;
+  // Needed as the verifier won't operate with dynamically computed offsets and
+  // wants to ensure that any write won't be out of bounds. Note that only the
+  // actual unwound stack will be sent to userspace.
+  u64 addresses[MAX_STACK_DEPTH * 2];
 } native_stack_t;
 
 typedef struct {
-  int task_id;
   int pid;
-  // offset since system boot
+  int tid;
   u64 collected_at;
-} stack_sample_header_t;
+  native_stack_t stack;
+} sample_t;
 
 typedef struct {
-  stack_sample_header_t header;
-  native_stack_t        stack;
-  native_stack_t        kernel_stack;
-} stack_sample_t;
-
-typedef struct {
-  stack_sample_t stack;
-
   unsigned long long ip;
   unsigned long long sp;
   unsigned long long bp;
   unsigned long long lr;
-  int tail_calls;
-
+  u64 tail_calls;
+  sample_t sample;
 } unwind_state_t;
 
 enum event_type {

--- a/src/bpf/profiler_bindings.rs
+++ b/src/bpf/profiler_bindings.rs
@@ -9,9 +9,6 @@ use crate::unwind_info::types::CompactUnwindRow;
 
 include!(concat!(env!("OUT_DIR"), "/profiler_bindings.rs"));
 
-unsafe impl Plain for stack_sample_t {}
-unsafe impl Plain for stack_sample_header_t {}
-unsafe impl Plain for native_stack_t {}
 unsafe impl Plain for Event {}
 unsafe impl Plain for unwinder_stats_t {}
 unsafe impl Plain for exec_mappings_key {}

--- a/src/process.rs
+++ b/src/process.rs
@@ -57,10 +57,10 @@ pub struct ExecutableMappings(pub Vec<ExecutableMapping>);
 
 impl ExecutableMappings {
     /// Find the executable mapping a given virtual address falls into.
-    pub fn for_address(&self, virtual_address: u64) -> Option<&ExecutableMapping> {
+    pub fn for_address(&self, virtual_address: &u64) -> Option<&ExecutableMapping> {
         self.0
             .iter()
-            .find(|&mapping| (mapping.start_addr..mapping.end_addr).contains(&virtual_address))
+            .find(|&mapping| (mapping.start_addr..mapping.end_addr).contains(virtual_address))
     }
 }
 

--- a/src/profile/convert.rs
+++ b/src/profile/convert.rs
@@ -62,7 +62,7 @@ pub fn to_pprof(
                 continue;
             };
 
-            let Some(mapping) = info.mappings.for_address(virtual_address) else {
+            let Some(mapping) = info.mappings.for_address(&virtual_address) else {
                 // todo: maybe append an error frame for debugging?
                 continue;
             };
@@ -125,7 +125,7 @@ pub fn to_pprof(
                 continue;
             };
 
-            let Some(mapping) = info.mappings.for_address(virtual_address) else {
+            let Some(mapping) = info.mappings.for_address(&virtual_address) else {
                 // todo: maybe append an error frame for debugging?
                 continue;
             };
@@ -330,7 +330,7 @@ pub fn fetch_symbols_for_profile(
         };
 
         for frame in &sample.ustack {
-            let Some(mapping) = info.mappings.for_address(frame.virtual_address) else {
+            let Some(mapping) = info.mappings.for_address(&frame.virtual_address) else {
                 continue;
             };
 
@@ -427,7 +427,7 @@ fn symbolize_user_stack(
             continue;
         };
 
-        let Some(mapping) = info.mappings.for_address(frame.virtual_address) else {
+        let Some(mapping) = info.mappings.for_address(&frame.virtual_address) else {
             result.push(Frame::with_error(
                 frame.virtual_address,
                 "<could not find mapping>".to_string(),

--- a/src/profile/sample.rs
+++ b/src/profile/sample.rs
@@ -6,20 +6,73 @@ use anyhow::anyhow;
 use lightswitch_object::ExecutableId;
 use tracing::error;
 
-use crate::bpf::profiler_bindings::native_stack_t;
 use crate::kernel::KERNEL_PID;
 use crate::process::ObjectFileInfo;
 use crate::process::Pid;
 use crate::process::ProcessInfo;
 use crate::profile::Frame;
 
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+/// This *must* be in sync with the C struct `sample_t`.
+#[derive(Debug, Clone, PartialEq)]
 pub struct RawSample {
     pub pid: Pid,
     pub tid: Pid,
     pub collected_at: u64,
-    pub ustack: Option<native_stack_t>,
-    pub kstack: Option<native_stack_t>,
+    pub ustack: Vec<u64>,
+    pub kstack: Vec<u64>,
+}
+
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub enum RawSampleParsingError {
+    #[error("expected more bytes before the stack")]
+    BeforeStackTooSmall,
+    #[error("expected more bytes for the stack")]
+    StackTooSmall,
+    #[error("expected fewer bytes for the sample")]
+    SampleTooLarge,
+}
+
+/// The unwound stack trace, [`native_stack_t`], is stored in the last field of [`sample_t`] and only the
+/// useful data is sent to userspace. This means that every sample might have a different number of frames.
+/// This is similar to C99's "Flexible Array Fields" and it is the reason why we need to manually parse it
+/// as `plain` doesn't correctly know how to deal with this.
+impl RawSample {
+    pub fn from_bytes(data: &[u8]) -> Result<Self, RawSampleParsingError> {
+        let sample_len = data.len();
+        if sample_len < 24 {
+            return Err(RawSampleParsingError::BeforeStackTooSmall);
+        }
+        if sample_len > 24 + 127 * 2 * 8 {
+            return Err(RawSampleParsingError::SampleTooLarge);
+        }
+
+        let pid = i32::from_ne_bytes(data[0..4].try_into().unwrap());
+        let tid = i32::from_ne_bytes(data[4..8].try_into().unwrap());
+        let collected_at = u64::from_ne_bytes(data[8..16].try_into().unwrap());
+        let ulen = u32::from_ne_bytes(data[16..20].try_into().unwrap()) as usize;
+        let klen = u32::from_ne_bytes(data[20..24].try_into().unwrap()) as usize;
+
+        if sample_len < 24 + (ulen + klen) * 8 {
+            return Err(RawSampleParsingError::StackTooSmall);
+        }
+
+        let ustack = data[24..(24 + ulen * 8)]
+            .chunks_exact(8)
+            .map(|chunk| u64::from_ne_bytes(chunk.try_into().unwrap()))
+            .collect::<Vec<_>>();
+        let kstack = data[(24 + ulen * 8)..(24 + ulen * 8 + klen * 8)]
+            .chunks_exact(8)
+            .map(|chunk| u64::from_ne_bytes(chunk.try_into().unwrap()))
+            .collect::<Vec<_>>();
+
+        Ok(RawSample {
+            pid,
+            tid,
+            collected_at,
+            ustack,
+            kstack,
+        })
+    }
 }
 
 impl std::hash::Hash for RawSample {
@@ -35,27 +88,20 @@ impl std::hash::Hash for RawSample {
 
 impl fmt::Display for RawSample {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let format_native_stack = |native_stack: Option<native_stack_t>| -> String {
-            let mut res: Vec<String> = Vec::new();
-            match native_stack {
-                Some(native_stack) => {
-                    for (i, addr) in native_stack.addresses.into_iter().enumerate() {
-                        if native_stack.len <= i.try_into().unwrap() {
-                            break;
-                        }
-                        res.push(format!("{i:3}: {addr:#018x}"));
-                    }
-                }
-                None => res.push("NONE".into()),
-            };
+        let format_native_stack = |native_stack: &Vec<u64>| -> String {
+            let mut res = Vec::new();
+
+            for (i, virtual_address) in native_stack.iter().enumerate() {
+                res.push(format!("{i:3}: {virtual_address:#018x}"));
+            }
             format!("[{}]", res.join(","))
         };
 
         fmt.debug_struct("RawSample")
             .field("pid", &self.pid)
             .field("tid", &self.tid)
-            .field("ustack", &format_native_stack(self.ustack))
-            .field("kstack", &format_native_stack(self.kstack))
+            .field("ustack", &format_native_stack(&self.ustack))
+            .field("kstack", &format_native_stack(&self.kstack))
             .finish()
     }
 }
@@ -84,66 +130,54 @@ impl RawAggregatedSample {
             count: self.count,
         };
 
-        if let Some(native_stack) = self.sample.ustack {
-            let Some(info) = procs.get(&self.sample.pid) else {
-                return Err(anyhow!("process not found"));
+        let Some(info) = procs.get(&self.sample.pid) else {
+            return Err(anyhow!("process not found"));
+        };
+
+        for virtual_address in &self.sample.ustack {
+            let Some(mapping) = info.mappings.for_address(virtual_address) else {
+                continue;
             };
 
-            for (i, virtual_address) in native_stack.addresses.into_iter().enumerate() {
-                if native_stack.len <= i.try_into().unwrap() {
-                    break;
+            let file_offset = match objs.get(&mapping.executable_id) {
+                Some(obj) => obj.normalized_address(*virtual_address, mapping),
+                None => {
+                    error!("executable with id 0x{} not found", mapping.executable_id);
+                    None
                 }
+            };
 
-                let Some(mapping) = info.mappings.for_address(virtual_address) else {
-                    continue;
-                };
-
-                let file_offset = match objs.get(&mapping.executable_id) {
-                    Some(obj) => obj.normalized_address(virtual_address, mapping),
-                    None => {
-                        error!("executable with id 0x{} not found", mapping.executable_id);
-                        None
-                    }
-                };
-
-                processed_sample.ustack.push(Frame {
-                    virtual_address,
-                    file_offset,
-                    symbolization_result: None,
-                });
-            }
+            processed_sample.ustack.push(Frame {
+                virtual_address: *virtual_address,
+                file_offset,
+                symbolization_result: None,
+            });
         }
 
-        if let Some(kernel_stack) = self.sample.kstack {
-            let Some(info) = procs.get(&KERNEL_PID) else {
-                return Err(anyhow!("kernel process not found"));
+        let Some(info) = procs.get(&KERNEL_PID) else {
+            return Err(anyhow!("kernel process not found"));
+        };
+
+        for virtual_address in &self.sample.kstack {
+            let Some(mapping) = info.mappings.for_address(virtual_address) else {
+                continue;
             };
 
-            for (i, virtual_address) in kernel_stack.addresses.into_iter().enumerate() {
-                if kernel_stack.len <= i.try_into().unwrap() {
-                    break;
+            let file_offset = match objs.get(&mapping.executable_id) {
+                Some(obj) => obj.normalized_address(*virtual_address, mapping),
+                None => {
+                    error!("executable with id 0x{} not found", mapping.executable_id);
+                    None
                 }
+            };
 
-                let Some(mapping) = info.mappings.for_address(virtual_address) else {
-                    continue;
-                };
-
-                let file_offset = match objs.get(&mapping.executable_id) {
-                    Some(obj) => obj.normalized_address(virtual_address, mapping),
-                    None => {
-                        error!("executable with id 0x{} not found", mapping.executable_id);
-                        None
-                    }
-                };
-
-                // todo: revisit this as the file offset calculation won't work
-                // for kaslr
-                processed_sample.kstack.push(Frame {
-                    virtual_address,
-                    file_offset,
-                    symbolization_result: None,
-                });
-            }
+            // todo: revisit this as the file offset calculation won't work
+            // for kaslr
+            processed_sample.kstack.push(Frame {
+                virtual_address: *virtual_address,
+                file_offset,
+                symbolization_result: None,
+            });
         }
 
         if processed_sample.ustack.is_empty() && processed_sample.kstack.is_empty() {
@@ -213,35 +247,102 @@ pub type AggregatedProfile = Vec<AggregatedSample>;
 
 #[cfg(test)]
 mod tests {
+    use crate::bpf::profiler_bindings::native_stack_t;
+    use crate::bpf::profiler_bindings::sample_t;
     use crate::profile::SymbolizedFrame;
 
     use super::*;
 
     #[test]
+    fn test_sample_too_little_data() {
+        assert_eq!(
+            RawSample::from_bytes(&[0x12, 0x23]),
+            Err(RawSampleParsingError::BeforeStackTooSmall)
+        );
+
+        let c_sample = sample_t {
+            pid: 234,
+            tid: 987,
+            collected_at: 0xDEADBEEF,
+            stack: native_stack_t {
+                ulen: 2,
+                klen: 1,
+                addresses: [0; 254],
+            },
+        };
+        assert_eq!(
+            RawSample::from_bytes(&unsafe { plain::as_bytes(&c_sample) }[..30]),
+            Err(RawSampleParsingError::StackTooSmall)
+        );
+    }
+
+    #[test]
+    fn test_sample_too_large() {
+        let c_sample = sample_t {
+            pid: 234,
+            tid: 987,
+            collected_at: 0xDEADBEEF,
+            stack: native_stack_t {
+                ulen: 2,
+                klen: 1,
+                addresses: [0; 254],
+            },
+        };
+        let bytes = unsafe { plain::as_bytes(&c_sample) };
+        let mut new_bytes = Vec::from(bytes);
+        new_bytes.push(0x10);
+
+        assert_eq!(
+            RawSample::from_bytes(&new_bytes[..]),
+            Err(RawSampleParsingError::SampleTooLarge)
+        );
+    }
+
+    #[test]
+    fn test_sample_parsing() {
+        let mut c_sample = sample_t {
+            pid: 234,
+            tid: 987,
+            collected_at: 0xDEADBEEF,
+            stack: native_stack_t {
+                ulen: 2,
+                klen: 1,
+                addresses: [0; 254],
+            },
+        };
+
+        c_sample.stack.addresses[0] = 0xFFFBBBDDD;
+        c_sample.stack.addresses[1] = 0x113355770;
+        c_sample.stack.addresses[2] = 0xBBBAAADDD;
+        // Garbage data that shouldn't be read.
+        c_sample.stack.addresses[3] = 0xBADBADBAD;
+
+        assert_eq!(
+            RawSample::from_bytes(unsafe { plain::as_bytes(&c_sample) }),
+            Ok(RawSample {
+                pid: 234,
+                tid: 987,
+                collected_at: 0xDEADBEEF,
+                ustack: vec![0xFFFBBBDDD, 0x113355770],
+                kstack: vec![0xBBBAAADDD]
+            })
+        );
+    }
+
+    #[test]
     fn display_raw_aggregated_sample() {
-        let addrs = [0; 127];
-
         // User stack but no kernel stack
-        let mut ustack = addrs;
-        ustack[0] = 0xffff;
-        ustack[1] = 0xdeadbeef;
-
-        let ustack_data = Some(native_stack_t {
-            addresses: ustack,
-            len: 2,
-        });
-
         let raw_aggregated_sample = RawAggregatedSample {
             sample: RawSample {
                 pid: 1234,
                 tid: 1235,
                 collected_at: 1748865070,
-                ustack: ustack_data,
-                kstack: None,
+                ustack: vec![0xffff, 0xdeadbeef],
+                kstack: vec![],
             },
             count: 1,
         };
-        insta::assert_yaml_snapshot!(format!("{}", raw_aggregated_sample), @r#""RawAggregatedSample { sample: \"RawSample { pid: 1234, tid: 1235, ustack: \\\"[  0: 0x000000000000ffff,  1: 0x00000000deadbeef]\\\", kstack: \\\"[NONE]\\\" }\", count: 1 }""#);
+        insta::assert_yaml_snapshot!(format!("{}", raw_aggregated_sample), @r#""RawAggregatedSample { sample: \"RawSample { pid: 1234, tid: 1235, ustack: \\\"[  0: 0x000000000000ffff,  1: 0x00000000deadbeef]\\\", kstack: \\\"[]\\\" }\", count: 1 }""#);
 
         // No user or kernel stacks
         let raw_aggregated_sample = RawAggregatedSample {
@@ -249,64 +350,12 @@ mod tests {
                 pid: 1234,
                 tid: 1235,
                 collected_at: 1748865170,
-                ustack: None,
-                kstack: None,
+                ustack: vec![],
+                kstack: vec![],
             },
             count: 1,
         };
-        insta::assert_yaml_snapshot!(format!("{}", raw_aggregated_sample), @r#""RawAggregatedSample { sample: \"RawSample { pid: 1234, tid: 1235, ustack: \\\"[NONE]\\\", kstack: \\\"[NONE]\\\" }\", count: 1 }""#);
-
-        // user and kernel stacks
-        let mut ustack = addrs;
-        let ureplace: &[u64] = &[
-            0x007f7c91c82314,
-            0x007f7c91c4ff93,
-            0x007f7c91c5d8ae,
-            0x007f7c91c4d2c3,
-            0x007f7c91c45400,
-            0x007f7c91c10933,
-            0x007f7c91c38153,
-            0x007f7c91c331d9,
-            0x007f7c91dfa501,
-            0x007f7c91c16b05,
-            0x007f7c91e22038,
-            0x007f7c91e23fc6,
-        ];
-        ustack[..ureplace.len()].copy_from_slice(ureplace);
-
-        let mut kstack = addrs;
-        let kreplace: &[u64] = &[
-            0xffffffff8749ae51,
-            0xffffffffc04c4804,
-            0xffffffff874ddfd0,
-            0xffffffff874e0843,
-            0xffffffff874e0b8a,
-            0xffffffff8727f600,
-            0xffffffff8727f8a7,
-            0xffffffff87e0116e,
-        ];
-        kstack[..kreplace.len()].copy_from_slice(kreplace);
-
-        let ustack_data = Some(native_stack_t {
-            addresses: ustack,
-            len: ureplace.len() as u64,
-        });
-        let kstack_data = Some(native_stack_t {
-            addresses: kstack,
-            len: kreplace.len() as u64,
-        });
-
-        let raw_aggregated_sample = RawAggregatedSample {
-            sample: RawSample {
-                pid: 128821,
-                tid: 128822,
-                collected_at: 1748865070,
-                ustack: ustack_data,
-                kstack: kstack_data,
-            },
-            count: 42,
-        };
-        insta::assert_yaml_snapshot!(format!("{}", raw_aggregated_sample), @r#""RawAggregatedSample { sample: \"RawSample { pid: 128821, tid: 128822, ustack: \\\"[  0: 0x00007f7c91c82314,  1: 0x00007f7c91c4ff93,  2: 0x00007f7c91c5d8ae,  3: 0x00007f7c91c4d2c3,  4: 0x00007f7c91c45400,  5: 0x00007f7c91c10933,  6: 0x00007f7c91c38153,  7: 0x00007f7c91c331d9,  8: 0x00007f7c91dfa501,  9: 0x00007f7c91c16b05, 10: 0x00007f7c91e22038, 11: 0x00007f7c91e23fc6]\\\", kstack: \\\"[  0: 0xffffffff8749ae51,  1: 0xffffffffc04c4804,  2: 0xffffffff874ddfd0,  3: 0xffffffff874e0843,  4: 0xffffffff874e0b8a,  5: 0xffffffff8727f600,  6: 0xffffffff8727f8a7,  7: 0xffffffff87e0116e]\\\" }\", count: 42 }""#);
+        insta::assert_yaml_snapshot!(format!("{}", raw_aggregated_sample), @r#""RawAggregatedSample { sample: \"RawSample { pid: 1234, tid: 1235, ustack: \\\"[]\\\", kstack: \\\"[]\\\" }\", count: 1 }""#);
     }
 
     #[test]


### PR DESCRIPTION
As of now the whole `sample_t` is sent to userspace which is wasteful because stacks rarely have the maximum amount of frames we can store. This commit changes this to send the exact amount of frames that have been unwound.

Test Plan
=========

Added tests and ran for a a while without issues.