### PR TITLE
object: Use 2024 edition

### DIFF
--- a/lightswitch-object/Cargo.toml
+++ b/lightswitch-object/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lightswitch-object"
 version = "0.3.1"
-edition = "2021"
+edition = "2024"
 description = "Deals with object files"
 license = "MIT"
 repository = "https://github.com/javierhonduco/lightswitch"

--- a/lightswitch-object/src/kernel.rs
+++ b/lightswitch-object/src/kernel.rs
@@ -1,11 +1,11 @@
 use anyhow::anyhow;
-use object::elf::{FileHeader32, FileHeader64, ELF_NOTE_GNU, NT_GNU_BUILD_ID, PT_NOTE};
-use object::read::elf::FileHeader;
-use object::read::elf::NoteIterator;
-use object::read::elf::ProgramHeader;
 use object::Endianness;
 use object::FileKind;
 use object::ReadCache;
+use object::elf::{ELF_NOTE_GNU, FileHeader32, FileHeader64, NT_GNU_BUILD_ID, PT_NOTE};
+use object::read::elf::FileHeader;
+use object::read::elf::NoteIterator;
+use object::read::elf::ProgramHeader;
 use std::fs::File;
 
 use crate::BuildId;

--- a/lightswitch-object/src/lib.rs
+++ b/lightswitch-object/src/lib.rs
@@ -1,13 +1,12 @@
-#![feature(let_chains)]
 mod buildid;
 pub mod kernel;
 mod object;
 
-pub use object::code_hash;
 pub use object::ElfLoad;
 pub use object::ObjectFile;
 pub use object::Runtime;
 pub use object::StopUnwindingFrames;
+pub use object::code_hash;
 
 pub use buildid::BuildId;
 pub use buildid::ExecutableId;

--- a/lightswitch-object/src/object.rs
+++ b/lightswitch-object/src/object.rs
@@ -3,19 +3,19 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use memmap2::Mmap;
 use ring::digest::{Context, Digest, SHA256};
 
-use object::elf::{FileHeader32, FileHeader64, PF_X, PT_LOAD};
-use object::read::elf::FileHeader;
-use object::read::elf::ProgramHeader;
 use object::Endianness;
 use object::FileKind;
 use object::Object;
 use object::ObjectKind;
 use object::ObjectSection;
 use object::ObjectSymbol;
+use object::elf::{FileHeader32, FileHeader64, PF_X, PT_LOAD};
+use object::read::elf::FileHeader;
+use object::read::elf::ProgramHeader;
 
 use crate::{BuildId, ExecutableId};
 
@@ -109,10 +109,10 @@ impl ObjectFile {
 
         // Golang (the Go toolchain does not interpret these bytes as we do).
         for section in object.sections() {
-            if section.name()? == ".note.go.buildid" {
-                if let Ok(data) = section.data() {
-                    return Ok(BuildId::go_from_bytes(data)?);
-                }
+            if section.name()? == ".note.go.buildid"
+                && let Ok(data) = section.data()
+            {
+                return Ok(BuildId::go_from_bytes(data)?);
             }
         }
 
@@ -168,13 +168,12 @@ impl ObjectFile {
 
     pub fn is_go(&self) -> bool {
         for section in self.object.sections() {
-            if let Ok(section_name) = section.name() {
-                if section_name == ".gosymtab"
+            if let Ok(section_name) = section.name()
+                && (section_name == ".gosymtab"
                     || section_name == ".gopclntab"
-                    || section_name == ".note.go.buildid"
-                {
-                    return true;
-                }
+                    || section_name == ".note.go.buildid")
+            {
+                return true;
             }
         }
         false
@@ -263,10 +262,10 @@ pub fn code_hash(object: &object::File) -> Option<Digest> {
             continue;
         };
 
-        if section_name == ".text" {
-            if let Ok(section) = section.data() {
-                return Some(sha256_digest(section));
-            }
+        if section_name == ".text"
+            && let Ok(section) = section.data()
+        {
+            return Some(sha256_digest(section));
         }
     }
 


### PR DESCRIPTION
The current code won't compile with `cargo 1.90.0-nightly (6833aa715 2025-07-13)`

```
   Compiling lightswitch-object v0.3.1 (/Users/javierhonduco/src/lightswitch/lightswitch-object)
error: let chains are only allowed in Rust 2024 or later
   --> lightswitch-object/src/object.rs:158:30
    |
158 |                 if is_zig && let Some((low_address, high_address)) = zig_first_frame {
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```

Upgrading to 2024 edition to make this compile for older and newer versions of rustc.

Test Plan
=========

CI