### PR TITLE
Disable munmap tracer events until we fix them for RHEL 9.x

### DIFF
--- a/src/bpf/tracers.bpf.c
+++ b/src/bpf/tracers.bpf.c
@@ -7,28 +7,27 @@
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_core_read.h>
 
-
 typedef struct {
     u64 pid_tgid;
 } mmap_data_key_t;
 
 struct {
-  __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-  __uint(key_size, sizeof(u32));
-  __uint(value_size, sizeof(u32));
-  __uint(max_entries, 0);
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, sizeof(u32));
+    __uint(max_entries, 0);
 } tracer_events SEC(".maps");
 
 struct {
-  __uint(type, BPF_MAP_TYPE_RINGBUF);
-  __uint(max_entries, 256 * 1024 /* 256 KB */);
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 256 * 1024 /* 256 KB */);
 } tracer_events_rb SEC(".maps");
 
 struct {
-  __uint(type, BPF_MAP_TYPE_HASH);
-  __uint(max_entries, 500);
-  __type(key, mmap_data_key_t);
-  __type(value, u64);
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 500);
+    __type(key, mmap_data_key_t);
+    __type(value, u64);
 } tracked_munmap SEC(".maps");
 
 // Arguments from
@@ -43,10 +42,8 @@ struct munmap_entry_args {
     size_t len;
 };
 
-
 SEC("tracepoint/sched/sched_process_exit")
 int tracer_process_exit(void *ctx) {
-
     struct task_struct *task = (struct task_struct *)bpf_get_current_task_btf();
     unsigned int level = BPF_CORE_READ(task, nsproxy, pid_ns_for_children, level);
     int per_process_id = BPF_CORE_READ(task, group_leader, thread_pid, numbers[level].nr);
@@ -82,67 +79,67 @@ int tracer_process_exit(void *ctx) {
     return 0;
 }
 
-SEC("tracepoint/syscalls/sys_enter_munmap")
-int tracer_enter_munmap(struct munmap_entry_args *args) {
-    u64 start_address = args->addr;
-    struct task_struct *task = (struct task_struct *)bpf_get_current_task_btf();
-    unsigned int level = BPF_CORE_READ(task, nsproxy, pid_ns_for_children, level);
-    int per_process_id = BPF_CORE_READ(task, group_leader, thread_pid, numbers[level].nr);
+// SEC("tracepoint/syscalls/sys_enter_munmap")
+// int tracer_enter_munmap(struct munmap_entry_args *args) {
+//     u64 start_address = args->addr;
+//     struct task_struct *task = (struct task_struct *)bpf_get_current_task_btf();
+//     unsigned int level = BPF_CORE_READ(task, nsproxy, pid_ns_for_children, level);
+//     int per_process_id = BPF_CORE_READ(task, group_leader, thread_pid, numbers[level].nr);
+//
+//     // We might not know about some mappings, but also we definitely don't want to notify
+//     // of non-executable mappings being unmapped.
+//     mapping_t *mapping = find_mapping(per_process_id, start_address);
+//     if (mapping == NULL){
+//         return 0;
+//     }
+//
+//     // Ensure we didn't get a process entry.
+//     if (start_address < mapping->begin || start_address >= mapping->end) {
+//       return 0;
+//     }
+//
+//     mmap_data_key_t key = {
+//         .pid_tgid = bpf_get_current_pid_tgid(),
+//     };
+//     bpf_map_update_elem(&tracked_munmap, &key, &start_address, BPF_ANY);
+//
+//     return 0;
+// }
 
-    // We might not know about some mappings, but also we definitely don't want to notify
-    // of non-executable mappings being unmapped.
-    mapping_t *mapping = find_mapping(per_process_id, start_address);
-    if (mapping == NULL){
-        return 0;
-    }
-
-    // Ensure we didn't get a process entry.
-    if (start_address < mapping->begin || start_address >= mapping->end) {
-      return 0;
-    }
-
-    mmap_data_key_t key = {
-        .pid_tgid = bpf_get_current_pid_tgid(),
-    };
-    bpf_map_update_elem(&tracked_munmap, &key, &start_address, BPF_ANY);
-
-    return 0;
-}
-
-SEC("tracepoint/syscalls/sys_exit_munmap")
-int tracer_exit_munmap(struct trace_event_raw_sys_exit *ctx) {
-    mmap_data_key_t key = {
-        .pid_tgid = bpf_get_current_pid_tgid(),
-    };
-
-    u64 *start_address = bpf_map_lookup_elem(&tracked_munmap, &key);
-    if (start_address == NULL) {
-        return 0;
-    }
-
-    int ret = ctx->ret;
-    if (ret != 0)  {
-        return 0;
-    }
-
-    LOG("[debug] sending munmap event");
-
-    tracer_event_t event = {
-        .type = TRACER_EVENT_TYPE_MUNMAP,
-        .pid = bpf_get_current_pid_tgid() >> 32,
-        .start_address = *start_address,
-    };
-
-    if (lightswitch_config.use_ring_buffers) {
-        ret = bpf_ringbuf_output(&tracer_events_rb, &event, sizeof(tracer_event_t), 0);
-    } else {
-        ret = bpf_perf_event_output(ctx, &tracer_events, BPF_F_CURRENT_CPU, &event, sizeof(tracer_event_t));
-    }
-    if (ret < 0) {
-        LOG("[error] failed to send munmap tracer event");
-    }
-
-    return 0;
-}
+// SEC("tracepoint/syscalls/sys_exit_munmap")
+// int tracer_exit_munmap(struct trace_event_raw_sys_exit *ctx) {
+//     mmap_data_key_t key = {
+//         .pid_tgid = bpf_get_current_pid_tgid(),
+//     };
+//
+//     u64 *start_address = bpf_map_lookup_elem(&tracked_munmap, &key);
+//     if (start_address == NULL) {
+//         return 0;
+//     }
+//
+//     int ret = ctx->ret;
+//     if (ret != 0)  {
+//         return 0;
+//     }
+//
+//     LOG("[debug] sending munmap event");
+//
+//     tracer_event_t event = {
+//         .type = TRACER_EVENT_TYPE_MUNMAP,
+//         .pid = bpf_get_current_pid_tgid() >> 32,
+//         .start_address = *start_address,
+//     };
+//
+//     if (lightswitch_config.use_ring_buffers) {
+//         ret = bpf_ringbuf_output(&tracer_events_rb, &event, sizeof(tracer_event_t), 0);
+//     } else {
+//         ret = bpf_perf_event_output(ctx, &tracer_events, BPF_F_CURRENT_CPU, &event, sizeof(tracer_event_t));
+//     }
+//     if (ret < 0) {
+//         LOG("[error] failed to send munmap tracer event");
+//     }
+//
+//     return 0;
+// }
 
 char LICENSE[] SEC("license") = "Dual MIT/GPL";


### PR DESCRIPTION
Upon upgrading to RHEL 9.x, the code related to munmap tracer events requires modification or it won't even compile in it's current form due to the munmap entry args [here](https://github.com/javierhonduco/lightswitch/blob/main/src/bpf/tracers.bpf.c#L36) being incorrect on later kernels.

Even after fixing that and getting a clean compile, the munmap tracepoint functions won't run and cause lightswitch to panic without any obvious errors or bpf logs that would indicate the source of the problem.

Disabling for the short term, while we work on the much more important issue of cleaning up processes and mappings, for which the process exit tracepoint is still working.