### PR TITLE
Add from_bytes for exec_mappings_key so we can extract PID

### DIFF
--- a/src/bpf/profiler_bindings.rs
+++ b/src/bpf/profiler_bindings.rs
@@ -35,7 +35,7 @@ impl exec_mappings_key {
         let p: &Self = plain::from_bytes(bytes)?;
         Ok(Self {
             prefix_len: p.prefix_len,
-            pid: u32::from_be(p.pid),
+            pid: i32::from_be(p.pid),
             data: u64::from_be(p.data),
         })
     }


### PR DESCRIPTION
A conversion `from_bytes` of a exec_mappings_key back into the Rust struct is needed for cases when we need to check whether a given PID still has entries in the `exec_mappings` BPF map.