### PR TITLE
Never choose PID 0 (KERNEL_PID) as eviction victim

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -1765,10 +1765,10 @@ impl Profiler {
 
         let mut to_evict = None;
         if should_evict {
-            // Make sure we never pick PID 0 (the kernel) as an eviction victim
+            // Make sure we never pick KERNEL_PID as an eviction victim
             let victim = running_procs
                 .sorted_by(|a, b| a.1.last_used.cmp(&b.1.last_used))
-                .find(|e| *e.0 != 0);
+                .find(|e| *e.0 != KERNEL_PID);
 
             if let Some((pid, _)) = victim {
                 to_evict = Some(*pid);


### PR DESCRIPTION
PID 0 isn't really a valid PID/user process - it has a special meaning as the kernel itself.

As such, we should never attempt to evict its data structures as part of the process eviction procedures.