### PR TITLE
Use s32/i32 as PID data type consistently

### DIFF
--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -129,7 +129,8 @@ typedef struct {
 // in the kernel in struct bpf_lpm_trie_key.
 struct exec_mappings_key {
     u32 prefix_len;
-    u32 pid;
+    // Per /usr/include/bits/typesizes.h, __PID_T_TYPE is S32 (i32 in Rust)
+    s32 pid;
     u64 data;
 };
 

--- a/src/bpf/profiler_bindings.rs
+++ b/src/bpf/profiler_bindings.rs
@@ -17,7 +17,7 @@ unsafe impl Plain for page_key_t {}
 unsafe impl Plain for page_value_t {}
 
 impl exec_mappings_key {
-    pub fn new(pid: u32, address: u64, prefix_len: u32) -> Self {
+    pub fn new(pid: i32, address: u64, prefix_len: u32) -> Self {
         let key_size_bits = std::mem::size_of::<Self>() * 8;
         assert!(
             prefix_len <= key_size_bits.try_into().unwrap(),

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -1190,7 +1190,7 @@ impl Profiler {
 
     fn add_bpf_process(bpf: &ProfilerSkel, pid: Pid) -> Result<(), libbpf_rs::Error> {
         let key = exec_mappings_key::new(
-            pid as u32, 0x0, 32, // pid bits
+            pid, 0x0, 32, // pid bits
         );
         Self::add_bpf_mapping(
             bpf,
@@ -1213,11 +1213,8 @@ impl Profiler {
     ) -> Result<(), libbpf_rs::Error> {
         for mapping in mappings {
             for address_range in summarize_address_range(mapping.begin, mapping.end - 1) {
-                let key = exec_mappings_key::new(
-                    pid as u32,
-                    address_range.addr,
-                    32 + address_range.prefix_len,
-                );
+                let key =
+                    exec_mappings_key::new(pid, address_range.addr, 32 + address_range.prefix_len);
 
                 Self::add_bpf_mapping(bpf, &key, mapping)?
             }
@@ -1233,11 +1230,8 @@ impl Profiler {
         partial_write: bool,
     ) {
         for address_range in summarize_address_range(mapping_begin, mapping_end - 1) {
-            let key = exec_mappings_key::new(
-                pid as u32,
-                address_range.addr,
-                32 + address_range.prefix_len,
-            );
+            let key =
+                exec_mappings_key::new(pid, address_range.addr, 32 + address_range.prefix_len);
 
             // TODO keep track of errors
             let res = bpf
@@ -1257,7 +1251,7 @@ impl Profiler {
 
     fn delete_bpf_process(bpf: &ProfilerSkel, pid: Pid) -> Result<(), libbpf_rs::Error> {
         let key = exec_mappings_key::new(
-            pid as u32, 0x0, 32, // pid bits
+            pid, 0x0, 32, // pid bits
         );
         bpf.maps
             .exec_mappings


### PR DESCRIPTION
This resolves Issue https://github.com/javierhonduco/lightswitch/issues/335