### PR TITLE
Ensure logic of maybe_evict_process is as intended

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -1745,17 +1745,20 @@ impl Profiler {
         }
     }
 
-    /// Evicts a process. If *if_too_many_procs* is true, this will only be done if there are more
+    /// Evicts a process. If *too_many_procs* is true, this will only be done if there are more
     /// processes with  [`ProcessStatus::Running`] status than the maximum number of processes, [`MAX_PROCESSES`].
     /// Returns false only if an eviction is necessary but not enough time has elapsed since the last one.
-    fn maybe_evict_process(&mut self, if_too_many_procs: bool) -> bool {
+    fn maybe_evict_process(&mut self, too_many_procs: bool) -> bool {
         let procs = self.procs.read();
         let running_procs = procs
             .iter()
             .filter(|e| e.1.status == ProcessStatus::Running);
-        let should_evict = if if_too_many_procs {
+        let should_evict = if too_many_procs {
+            // Only evict if we *still* have too many processes - otherwise don't
             running_procs.clone().count() >= MAX_PROCESSES as usize
         } else {
+            // Evict even if we don't know if there are too many processes?
+            // Or should this be false?
             true
         };
 


### PR DESCRIPTION
Not clear if variable `should_evict` should be set to true if `too_many_processes` is set to false.

This might indeed be the intent, but don't understand the reasoning behind it.

Also changed `if_too_many_procs` to just `too_many_procs`, because `if if_too_many_procs` looks really weird.