### PR TITLE
Extract unwind_info_len for each executable id when evicting unwind info

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -1627,14 +1627,9 @@ impl Profiler {
             return false;
         }
 
-        // We should print informational logs if we're going to need to evict for now
+        // We should print info log if we're going to need to evict for now
         if to_free_mb > 0 {
             info!(
-                "unwind information size to free {} MB (used {} MB / {} MB)",
-                to_free_mb, total_memory_used_mb, max_memory_mb
-            );
-        } else {
-            debug!(
                 "unwind information size to free {} MB (used {} MB / {} MB)",
                 to_free_mb, total_memory_used_mb, max_memory_mb
             );


### PR DESCRIPTION
Instead of using the `unwind_info_len` passed as an argument into `maybe_evict_executables()` again and again when iterating over the known executables, pull the individual `unwind_info_len` fields out of each `KnownExecutableInfo`

- minor comment typo
- Make log message about eviction an info message when actually evicting

This may resolve https://github.com/javierhonduco/lightswitch/issues/347