### PR TITLE
Use the default implementation in DeletionScheduler ctor

### DIFF
--- a/src/deletion_scheduler.rs
+++ b/src/deletion_scheduler.rs
@@ -10,9 +10,7 @@ pub struct DeletionScheduler {
 
 impl DeletionScheduler {
     pub fn new() -> Self {
-        DeletionScheduler {
-            heap: BinaryHeap::new(),
-        }
+        Self::default()
     }
 
     pub fn add(&mut self, item: ToDelete) {


### PR DESCRIPTION
Missed doing this in #340 - After going to the trouble of deriving the default implementation for DeletionScheduler, go ahead and use it in the constructor.