### PR TITLE
Custom BTF loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 - Fix automatic enablement of `task_pt_regs_helper` if the necessary features are present as well as a bug that made the code be rejected when enabled
 - Fix panic during teardown due to attempting to send data to a closed channel
+- Add support for custom BTF path
 
 v0.3.1
 ---------

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,9 +1214,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libbpf-cargo"
-version = "0.26.0-beta.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f67e781e4af482d9fb558bcf9fe601c8f1188614d08694ceb4c2f0b35b5fd3f"
+checksum = "2df559c3961ae45e06aaff479036261375dbf0226541aa4155e60aa277fb37d6"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1233,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "libbpf-rs"
-version = "0.26.0-beta.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7129813a2bcf27f1751fa7bf88bee2e2e2cd81a41c0b9cf6a5aab16ab150ab2f"
+checksum = "87c7c1017b506e5cbc007f65abb78b21bd5957dff9358882427ddbf634ba415b"
 dependencies = [
  "bitflags",
  "libbpf-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 memmap2 = "0.9.9"
 anyhow = "1.0.100"
 object = "0.38.0"
-libbpf-rs = { version = "0.26.0-beta.1", features = ["static"] }
+libbpf-rs = { version = "0.26.0", features = ["static"] }
 tracing = "0.1.43"
 thiserror = "2.0.17"
 perf-event-open-sys = "5.0.0"
@@ -26,7 +26,7 @@ procfs = "0.18.0"
 nix = { version = "0.30.1" }
 # workspace dev dependencies below
 # workspace build dependencies below
-libbpf-cargo = { version = "0.26.0-beta.1" }
+libbpf-cargo = { version = "0.26.0" }
 glob = "0.3.3"
 ring = "0.17.14"
 libbpf-sys = "1.6.1"

--- a/docs/btf.md
+++ b/docs/btf.md
@@ -1,0 +1,35 @@
+BTF (BPF Type Format)
+=====================
+
+[BTF](https://docs.kernel.org/bpf/btf.html) is required by libbpf to perform the necessary changes to be able to load a program and maps in different versions of the kernel thanks to [CO-RE](https://docs.ebpf.io/concepts/core/, which might have different data layouts.
+Certain kernels, such as Raspbian (Raspberry Pi) or Nvidia (Jetson boards) don't ship with BTF to save on disk space. To allow lightswitch to be loaded, a BTF file has to be provided via the `--btf-custom-path` flag.
+
+There are two ways to source it:
+- Download an already generated BTF file from [BTFhub](https://github.com/aquasecurity/btfhub-archive) trying to match your distro and kernel version to the closest one;
+- Generating a BTF file yourself. This option is best as it would ensure maximum compatibility and reduce the changes of mismatches.
+
+
+## Generating a BTF file for Raspbian
+
+1. Fetch the [kernel sources](https://github.com/raspberrypi/linux);
+1. Check your current kernel release `uname -r`;
+1. Find the commit that bumped the kernel release to the one you use in [the firmware repo](https://github.com/raspberrypi/rpi-firmware/commits/master) and checkout to the new revision in `git_hash`;
+1. Follow [the official guide](https://www.raspberrypi.com/documentation/computers/linux_kernel.html) on how to configure it;
+1. Modify the configuration for your Raspberry Pi model
+    ```
+    javierhonduco@fedora:~/src/raspberrypi-linux$ git diff
+    diff --git a/arch/arm64/configs/bcm2711_defconfig b/arch/arm64/configs/bcm2711_defconfig
+    index 452a26ae3d69..955997adcc9d 100644
+    --- a/arch/arm64/configs/bcm2711_defconfig
+    +++ b/arch/arm64/configs/bcm2711_defconfig
+    @@ -1762,3 +1762,6 @@ CONFIG_FTRACE_SYSCALLS=y
+    CONFIG_BLK_DEV_IO_TRACE=y
+    # CONFIG_UPROBE_EVENTS is not set
+    # CONFIG_STRICT_DEVMEM is not set
+    +CONFIG_DEBUG_INFO=y
+    +CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT=y
+    +CONFIG_DEBUG_INFO_BTF=y
+    ```
+1. Build your kernel following the official guide;
+1. Extract the BTF information from the kernel image with `pahole --btf_encode_detached extracted.btf vmlinux`
+1. Run lightswitch with `--btf-custom-path=extracted.btf`

--- a/lightswitch-capabilities/CHANGELOG.md
+++ b/lightswitch-capabilities/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 - Add feature detection for the `bpf_get_current_task_btf()` helper
+- Add support for custom BTF path
 
 v0.2.2
 ------

--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -76,6 +76,7 @@ struct lightswitch_config_t {
     bool verbose_logging;
     bool use_ring_buffers;
     bool use_task_pt_regs_helper;
+    bool use_btf_helpers;
 };
 
 struct unwinder_stats_t {

--- a/src/bpf/shared_helpers.h
+++ b/src/bpf/shared_helpers.h
@@ -1,5 +1,36 @@
+#include "constants.h"
 
-static __always_inline mapping_t* find_mapping(int per_process_id, u64 pc) {
+
+static __always_inline struct task_struct *current_task() {
+    if (lightswitch_config.use_task_pt_regs_helper && lightswitch_config.use_btf_helpers) {
+        return bpf_get_current_task_btf();
+    } else {
+        return (struct task_struct *)bpf_get_current_task();
+    }
+}
+
+static __always_inline struct pt_regs *pt_regs(struct task_struct *task) {
+    if (lightswitch_config.use_task_pt_regs_helper && lightswitch_config.use_btf_helpers) {
+        if (task == NULL) {
+            return NULL;
+        }
+        return (struct pt_regs *)bpf_task_pt_regs(task);
+    } else {
+        if (task == NULL) {
+            return NULL;
+        }
+        void *stack;
+        int err = bpf_probe_read_kernel(&stack, 8, &task->stack);
+        if (err) {
+            LOG("[warn] bpf_probe_read_kernel failed with %d", err);
+            return NULL;
+        }
+        void *ptr = stack + THREAD_SIZE - TOP_OF_KERNEL_STACK_PADDING;
+        return ((struct pt_regs *)ptr) - 1;
+    }
+}
+
+static __always_inline mapping_t *find_mapping(int per_process_id, u64 pc) {
     struct exec_mappings_key key = {};
     key.prefix_len = PREFIX_LEN;
     key.pid = __builtin_bswap32((u32)per_process_id);

--- a/src/bpf/tracers.bpf.c
+++ b/src/bpf/tracers.bpf.c
@@ -44,7 +44,7 @@ struct munmap_entry_args {
 
 SEC("tracepoint/sched/sched_process_exit")
 int tracer_process_exit(void *ctx) {
-    struct task_struct *task = (struct task_struct *)bpf_get_current_task_btf();
+    struct task_struct *task = current_task();
     unsigned int level = BPF_CORE_READ(task, nsproxy, pid_ns_for_children, level);
     int per_process_id = BPF_CORE_READ(task, group_leader, thread_pid, numbers[level].nr);
     int per_thread_id = BPF_CORE_READ(task, thread_pid, numbers[level].nr);
@@ -82,7 +82,7 @@ int tracer_process_exit(void *ctx) {
 SEC("tracepoint/syscalls/sys_enter_munmap")
 int tracer_enter_munmap(struct munmap_entry_args *args) {
     u64 start_address = args->addr;
-    struct task_struct *task = (struct task_struct *)bpf_get_current_task_btf();
+    struct task_struct *task = current_task();
     unsigned int level = BPF_CORE_READ(task, nsproxy, pid_ns_for_children, level);
     int per_process_id = BPF_CORE_READ(task, group_leader, thread_pid, numbers[level].nr);
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -80,6 +80,9 @@ pub(crate) struct CliArgs {
     /// Enable BPF programs logging
     #[arg(long)]
     pub(crate) bpf_logging: bool,
+    /// Alternative BTF file.
+    #[arg(long)]
+    pub(crate) btf_custom_path: Option<String>,
     /// Set lightswitch's logging level
     #[arg(long, default_value_t, value_enum)]
     pub(crate) logging: LoggingLevel,


### PR DESCRIPTION
Some linux distributions don't come with kernel debug information in BTF
format which is required by libbpf to relocate the BPF programs. Among
said cases, there are two pretty popular ones: Raspbian, commonly used
in Raspberry Pis, and the kernels Nvidia ships with their jetson
hardware line, among others.

In kernels that lack BTF (typically located at /sys/kernel/btf/vmlinux)
but might be elsewhere, this flag must be used to be able to run
lightswitch.

There's a new documentation file with more information on how to
generate the BTF file that's needed on Raspbian but it should be pretty
similar across distros.

Note that BTF helpers can't be used on kernels that don't have BTF as
this info is required by the verifier to be able to load these programs,
so the non-BTF option will be selected. Among other things, it will
change the implementation to fetch userspace registers from a kernel
context.

This patch doesn't add automatic downloading of BTF debug info and
should be provided by the user.

Test Plan
=========

Added integration tests and tested on a Raspberry Pi 4:

```
javierhonduco@raspberrypi:~ $ uname -a
Linux raspberrypi 6.12.34+rpt-rpi-v8 https://github.com/javierhonduco/lightswitch/pull/1 SMP PREEMPT Debian 1:6.12.34-1+rpt1~bookworm (2025-06-26) aarch64 GNU/Linux
```

```
(nix:nix-shell-env) javierhonduco@raspberrypi:~/src/lightswitch $ time cargo run  -- --btf-custom-path /tmp/external.btf --duration 1 --sample-freq=997
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.54s
     Running `sudo -E target/debug/lightswitch --btf-custom-path /tmp/external.btf --duration 1 --sample-freq=997`
2026-02-15T15:45:01.023143Z  INFO lightswitch::profiler: native unwinder BPF program loaded
2026-02-15T15:45:01.065667Z  INFO lightswitch::profiler: munmap and process exit tracing BPF programs loaded
2026-02-15T15:45:01.067998Z ERROR lightswitch::profiler: fetching the kaslr offset failed with No such file or directory (os error 2), assuming it is 0
2026-02-15T15:45:02.782176Z  WARN lightswitch::profiler: error adding unwind information for executable 0x3055b9673a15ad63 due to NoUnwindInfo("write error", "/usr/lib/aarch64-linux-gnu/libXdmcp.so.6.0.0")
2026-02-15T15:45:02.782609Z  INFO lightswitch::profiler: stacks successfully unwound: 82.11%
2026-02-15T15:45:02.993878Z  INFO lightswitch: Symbolizing profile...
Flamegraph profile successfully written to flame.svg
```

While before:

```
(nix:nix-shell-env) javierhonduco@raspberrypi:~/src/lightswitch $ time cargo run
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.89s
     Running `sudo -E target/debug/lightswitch`
libbpf: kernel BTF is missing at '/sys/kernel/btf/vmlinux', was CONFIG_DEBUG_INFO_BTF enabled?
libbpf: failed to find valid kernel BTF
libbpf: Error loading vmlinux BTF: -ESRCH
libbpf: failed to load BPF skeleton 'features_bpf': -ESRCH
2026-02-15T15:44:06.634598Z  WARN lightswitch_capabilities::system_info: Failed to detect available BPF features BPF feature detection failed, err=No such process (os error 3)
2026-02-15T15:44:06.665435Z ERROR lightswitch: Some start up requirements could not be met!
2026-02-15T15:44:06.665541Z ERROR lightswitch: system_info = SystemInfo { os_release: "6.12.34+rpt-rpi-v8", procfs_mount_detected: true, tracefs_mount_detected: true, tracepoints_support_detected: true, software_perfevents_support_detected: true, available_bpf_features: BpfFeatures { can_load_trivial_bpf_program: false, has_ring_buf: false, has_tail_call: false, has_map_of_maps: false, has_batch_map_operations: false, has_mmapable_bpf_array: false, has_task_pt_regs_helper: false, has_get_current_task_btf: false, has_variable_inner_map: false } }
```

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>