### PR TITLE
wip: Read persisted unwind info without allocating everything in memory

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -3,10 +3,16 @@ use itertools::Itertools;
 use libbpf_rs::{MapCore, MapFlags, MapHandle, MapType};
 use lightswitch::bpf::profiler_bindings::stack_unwind_row_t;
 use lightswitch::ksym::KsymIter;
+use lightswitch::unwind_info::pages::to_pages;
+use lightswitch::unwind_info::persist::{Reader, Writer};
 use lightswitch::unwind_info::types::CompactUnwindRow;
 use lightswitch::util::roundup_page;
-use memmap2::MmapOptions;
+use memmap2::{Mmap, MmapOptions};
+use std::fs::File;
+use std::hint::black_box;
+use std::io::{BufReader, BufWriter, Cursor, Read};
 use std::os::fd::AsFd;
+use std::path::Path;
 
 pub fn benchmark_kysm_readallkysms(c: &mut Criterion) {
     let mut group = c.benchmark_group("Read /proc/kallsyms");
@@ -151,5 +157,125 @@ pub fn benchark_bpf_array(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, benchark_bpf_array, benchmark_kysm_readallkysms);
+/// Simulates the 3 unwind info reads done in profiler.rs when using an
+/// in-memory vec.
+///
+/// 1. add_bpf_unwind_info: iterate all rows
+/// 2. add_bpf_pages: iterate all rows via to_pages
+/// 3. Extract first/last PC addresses
+fn three_reads_from_vec(unwind_info: &[CompactUnwindRow]) {
+    let len = unwind_info.len();
+
+    // Read 1: iterate all rows (add_bpf_unwind_info).
+    for row in unwind_info.iter() {
+        black_box(row);
+    }
+
+    // Read 2: to_pages (add_bpf_pages).
+    let pages = to_pages(unwind_info.iter().copied().map(Ok), len).expect("unwind info pages");
+    black_box(pages);
+
+    // Read 3: first and last addresses.
+    black_box(unwind_info.first());
+    black_box(unwind_info.last());
+}
+
+/// Simulates the 3 unwind info reads done in profiler.rs when using the
+/// streaming Reader (the current branch approach):
+///
+/// 1. add_bpf_unwind_info: iterate all rows via reader.iter()
+/// 2. add_bpf_pages: iterate all rows via reader.iter() -> to_pages
+/// 3. Extract first/last PC addresses via reader.first()/last()
+fn three_reads_from_reader<R: Read + std::io::Seek>(reader: &mut Reader<R>) {
+    let len = reader.len();
+
+    // Read 1: iterate all rows (add_bpf_unwind_info).
+    for row in reader.iter() {
+        black_box(row.unwrap());
+    }
+
+    // Read 2: to_pages (add_bpf_pages).
+    let pages = to_pages(reader.iter(), len).expect("unwind info pages");
+    black_box(pages);
+
+    // Read 3: first and last addresses.
+    black_box(reader.first());
+    black_box(reader.last());
+}
+
+pub fn benchmark_unwind_info_reader(c: &mut Criterion) {
+    // Setup: write unwind info for /proc/self/exe to a temp file.
+    let tmpfile = tempfile::NamedTempFile::new().unwrap();
+    let writer = Writer::new(Path::new("/proc/self/exe"), None);
+    let mut buf_writer = BufWriter::new(tmpfile.as_file().try_clone().unwrap());
+    writer.write(&mut buf_writer).unwrap();
+    // Force flush
+    drop(buf_writer);
+    let path = tmpfile.path().to_path_buf();
+
+    // Report the number of unwind rows for context.
+    {
+        let file = File::open(&path).unwrap();
+        let reader = Reader::new(BufReader::new(file), false).unwrap();
+        assert!(reader.len() > 1000);
+        eprintln!("Unwind info entries: {}", reader.len());
+    }
+
+    let mut group = c.benchmark_group("Unwind info reader (3 times)");
+
+    group.bench_function("in-memory (old implementation)", |b| {
+        b.iter(|| {
+            let mut data = Vec::new();
+            BufReader::new(File::open(&path).unwrap())
+                .read_to_end(&mut data)
+                .unwrap();
+            let reader = Reader::new(Cursor::new(data), false).unwrap();
+            #[allow(deprecated)]
+            let unwind_info = reader.as_vec_no_iter().unwrap();
+            three_reads_from_vec(&unwind_info);
+        })
+    });
+
+    // Main branch approach: read entire file into Vec<u8>, parse all
+    // rows into Vec<CompactUnwindRow>, then iterate the Vec 3 times.
+    group.bench_function("in-memory (new implementation)", |b| {
+        b.iter(|| {
+            let mut data = Vec::new();
+            BufReader::new(File::open(&path).unwrap())
+                .read_to_end(&mut data)
+                .unwrap();
+            let mut reader = Reader::new(Cursor::new(data), false).unwrap();
+            let unwind_info = reader.as_vec().unwrap();
+            three_reads_from_vec(&unwind_info);
+        })
+    });
+
+    // Current branch approach: mmap the file, stream through it 3 times.
+    group.bench_function("mmap reader (new implementation)", |b| {
+        b.iter(|| {
+            let file = File::open(&path).unwrap();
+            let mmap = unsafe { Mmap::map(&file) }.unwrap();
+            let mut reader = Reader::new(Cursor::new(mmap), false).unwrap();
+            three_reads_from_reader(&mut reader);
+        })
+    });
+
+    // BufReader<File> streaming for comparison.
+    group.bench_function("buffered file reader (new implementation)", |b| {
+        b.iter(|| {
+            let file = File::open(&path).unwrap();
+            let mut reader = Reader::new(BufReader::new(file), false).unwrap();
+            three_reads_from_reader(&mut reader);
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    benchark_bpf_array,
+    benchmark_kysm_readallkysms,
+    benchmark_unwind_info_reader
+);
 criterion_main!(benches);

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -1,6 +1,7 @@
 use crate::deletion_scheduler::DeletionScheduler;
 use crate::deletion_scheduler::ToDelete;
 use crate::process::opened_exe_path;
+use crate::unwind_info::pages::Page;
 use crate::util::FileId;
 use libbpf_rs::MapImpl;
 use libbpf_rs::OpenObject;
@@ -23,7 +24,6 @@ use std::mem::ManuallyDrop;
 use std::mem::MaybeUninit;
 use std::num::NonZeroUsize;
 use std::os::fd::{AsFd, AsRawFd};
-
 use std::os::unix::fs::FileExt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -62,6 +62,9 @@ use crate::process::{
 };
 use crate::profile::*;
 use crate::unwind_info::manager::UnwindInfoManager;
+use crate::unwind_info::pages::to_pages;
+use crate::unwind_info::persist::ReaderError;
+use crate::unwind_info::source::UnwindInfoSource;
 use crate::unwind_info::types::CompactUnwindRow;
 use crate::util::executable_path;
 use crate::util::page_size;
@@ -299,6 +302,8 @@ enum AddUnwindInformationError {
     Generic(String, String),
     #[error("unwind information contains no entries")]
     Empty,
+    #[error("failed to generate unwind information pages: {0}")]
+    Pages(String),
     #[error("failed to write to BPF map that stores unwind information: {0}")]
     BpfUnwindInfo(String),
     #[error("failed to write to BPF map that stores pages: {0}")]
@@ -649,7 +654,7 @@ impl Profiler {
             exclude_self: profiler_config.exclude_self,
             debug_info_manager: profiler_config.debug_info_manager,
             max_native_unwind_info_size_mb: profiler_config.max_native_unwind_info_size_mb,
-            unwind_info_manager: UnwindInfoManager::new(&unwind_cache_dir, None),
+            unwind_info_manager: UnwindInfoManager::from_mmap(&unwind_cache_dir, None),
             use_ring_buffers: profiler_config.use_ring_buffers,
             aggregator: Aggregator::default(),
             metadata_provider,
@@ -751,7 +756,7 @@ impl Profiler {
             }
             Err(e) => {
                 error!(
-                    "fetching the kaslr offset failed with {:?}, assuming it is 0",
+                    "fetching the kaslr offset failed with `{:?}`, assuming it is 0",
                     e
                 );
                 0
@@ -1225,9 +1230,10 @@ impl Profiler {
 
     fn add_bpf_unwind_info(
         inner: &MapHandle,
-        unwind_info: &[CompactUnwindRow],
+        unwind_info: impl Iterator<Item = Result<CompactUnwindRow, ReaderError>>,
+        unwind_info_len: usize,
     ) -> Result<(), anyhow::Error> {
-        let size = inner.value_size() as usize * unwind_info.len();
+        let size = inner.value_size() as usize * unwind_info_len;
         let mut mmap = unsafe {
             MmapOptions::new()
                 .len(roundup_page(size))
@@ -1235,10 +1241,11 @@ impl Profiler {
         }?;
         let (prefix, middle, suffix) = unsafe { mmap.align_to_mut::<stack_unwind_row_t>() };
         assert_eq!(prefix.len(), 0);
+        // TODO: ensure middle.len() has the right size
         assert_eq!(suffix.len(), 0);
 
-        for (row, write) in unwind_info.iter().zip(middle) {
-            *write = row.into();
+        for (row, write) in unwind_info.zip(middle) {
+            *write = (&row?).into();
         }
 
         Ok(())
@@ -1246,10 +1253,9 @@ impl Profiler {
 
     fn add_bpf_pages(
         bpf: &ProfilerSkel,
-        unwind_info: &[CompactUnwindRow],
+        pages: Vec<Page>,
         executable_id: u64,
     ) -> Result<(), libbpf_rs::Error> {
-        let pages = crate::unwind_info::pages::to_pages(unwind_info);
         for page in pages {
             let page_key = page_key_t {
                 file_offset: page.address,
@@ -1618,7 +1624,6 @@ impl Profiler {
                     return Err(AddUnwindInformationError::StrippedGo);
                 }
                 let mut unwind_info = Vec::new();
-
                 // For each bottom frame, add a end of function marker to stop unwinding
                 // covering the exact size of the function, assuming the function after it
                 // has frame pointers.
@@ -1635,7 +1640,7 @@ impl Profiler {
                 unwind_info.push(CompactUnwindRow::stop_unwinding(end_address));
 
                 unwind_info.sort_by_key(|e| e.pc);
-                Ok(unwind_info)
+                Ok(UnwindInfoSource::Vector(unwind_info))
             }
             Runtime::Zig {
                 start_low_address,
@@ -1649,20 +1654,22 @@ impl Profiler {
                     executable_path.display()
                 )
                 .entered();
-                self.unwind_info_manager.fetch_unwind_info(
+                let reader = self.unwind_info_manager.fetch_unwind_info(
                     &opened_exe_path,
                     executable_id,
                     Some((start_low_address, start_high_address)),
                     false,
-                )
+                );
+
+                reader.map(UnwindInfoSource::Reader)
             }
             Runtime::CLike => {
                 if needs_synthesis {
                     debug!("synthetising arm64 unwind information using frame pointers for vDSO");
-                    Ok(vec![
+                    Ok(UnwindInfoSource::Vector(vec![
                         CompactUnwindRow::frame_pointer(start_address, is_arm64),
                         CompactUnwindRow::stop_unwinding(end_address),
-                    ])
+                    ]))
                 } else {
                     let _span = span!(
                         Level::DEBUG,
@@ -1672,21 +1679,22 @@ impl Profiler {
                         executable_path.display()
                     )
                     .entered();
-                    self.unwind_info_manager.fetch_unwind_info(
+                    let reader = self.unwind_info_manager.fetch_unwind_info(
                         &opened_exe_path,
                         executable_id,
                         None,
                         false,
-                    )
+                    );
+                    reader.map(UnwindInfoSource::Reader)
                 }
             }
-            Runtime::V8 => Ok(vec![
+            Runtime::V8 => Ok(UnwindInfoSource::Vector(vec![
                 CompactUnwindRow::frame_pointer(start_address, is_arm64),
                 CompactUnwindRow::stop_unwinding(end_address),
-            ]),
+            ])),
         };
 
-        let unwind_info = match unwind_info {
+        let mut unwind_info = match unwind_info {
             Ok(unwind_info) => unwind_info,
             Err(e) => {
                 return Err(AddUnwindInformationError::Generic(
@@ -1700,40 +1708,49 @@ impl Profiler {
             }
         };
 
-        if !self.maybe_evict_executables(unwind_info.len(), self.max_native_unwind_info_size_mb) {
-            return Err(AddUnwindInformationError::Eviction);
-        }
-
         if unwind_info.is_empty() {
             self.afflicted_processes.put(pid, ());
             return Err(AddUnwindInformationError::Empty);
         }
 
-        if unwind_info.len() > MAX_UNWIND_INFO_SIZE {
+        let unwind_info_len = unwind_info.len();
+        if !self.maybe_evict_executables(unwind_info_len, self.max_native_unwind_info_size_mb) {
+            return Err(AddUnwindInformationError::Eviction);
+        }
+
+        if unwind_info_len > MAX_UNWIND_INFO_SIZE {
             self.afflicted_processes.put(pid, ());
             return Err(AddUnwindInformationError::TooLarge(
                 executable_path.to_string_lossy().to_string(),
-                unwind_info.len(),
+                unwind_info_len,
             ));
         }
 
         let inner_map = Self::create_and_insert_unwind_info_map(
             &mut self.native_unwinder,
             executable_id.into(),
-            unwind_info.len(),
+            unwind_info_len,
         );
 
-        // Add all unwind information and its pages.
-        Self::add_bpf_unwind_info(&inner_map, &unwind_info)
+        // Add all unwind information
+        Self::add_bpf_unwind_info(&inner_map, unwind_info.iter(), unwind_info_len)
             .map_err(|e| AddUnwindInformationError::BpfUnwindInfo(e.to_string()))?;
-        Self::add_bpf_pages(&self.native_unwinder, &unwind_info, executable_id.into())
+
+        let pages = to_pages(unwind_info.iter(), unwind_info_len)
+            .map_err(|e| AddUnwindInformationError::Pages(e.to_string()))?;
+
+        // Add pages
+        Self::add_bpf_pages(&self.native_unwinder, pages, executable_id.into())
             .map_err(|e| AddUnwindInformationError::BpfPages(e.to_string()))?;
+
+        // Get start and end addresses
         let unwind_info_start_address = unwind_info.first().unwrap().pc;
         let unwind_info_end_address = unwind_info.last().unwrap().pc;
+
         self.native_unwind_state.known_executables.insert(
             executable_id,
             KnownExecutableInfo {
-                unwind_info_len: unwind_info.len(),
+                unwind_info_len,
                 unwind_info_start_address,
                 unwind_info_end_address,
                 last_used: Instant::now(),

--- a/src/unwind_info/manager.rs
+++ b/src/unwind_info/manager.rs
@@ -1,21 +1,24 @@
 use lightswitch_object::ExecutableId;
+use memmap2::Mmap;
 use std::collections::BinaryHeap;
 use std::fs;
+use std::fs::File;
+use std::io::BufReader;
 use std::io::BufWriter;
+use std::io::Cursor;
 use std::io::ErrorKind;
 use std::io::Read;
+use std::io::Seek;
 use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Instant;
-use std::{fs::File, io::BufReader};
 
 use thiserror::Error;
 use tracing::debug;
 
 use super::persist::{Reader, Writer};
 use crate::unwind_info::persist::{ReaderError, WriterError};
-use crate::unwind_info::types::CompactUnwindRow;
 
 const DEFAULT_MAX_CACHED_FILES: usize = 1_000;
 
@@ -59,10 +62,20 @@ pub struct UnwindInfoManager {
     cache_dir: PathBuf,
     usage_tracking: BinaryHeap<Usage>,
     max_cached_files: usize,
+    file_opener: fn(path: &Path) -> std::io::Result<Box<dyn ReadSeek>>,
 }
 
+pub trait ReadSeek: Read + Seek {}
+impl ReadSeek for BufReader<File> {}
+impl ReadSeek for File {}
+impl<T: AsRef<[u8]>> ReadSeek for Cursor<T> {}
+
 impl UnwindInfoManager {
-    pub fn new(cache_dir: &Path, max_cached_files: Option<usize>) -> Self {
+    pub fn new(
+        cache_dir: &Path,
+        max_cached_files: Option<usize>,
+        file_opener: fn(path: &Path) -> std::io::Result<Box<dyn ReadSeek>>,
+    ) -> Self {
         let max_cached_files = max_cached_files.unwrap_or(DEFAULT_MAX_CACHED_FILES);
         debug!(
             "Storing unwind information cache in {}",
@@ -71,10 +84,26 @@ impl UnwindInfoManager {
         let mut manager = UnwindInfoManager {
             cache_dir: cache_dir.to_path_buf(),
             usage_tracking: BinaryHeap::with_capacity(max_cached_files),
+            file_opener,
             max_cached_files,
         };
         let _ = manager.bump_already_present();
         manager
+    }
+
+    pub fn from_file(cache_dir: &Path, max_cached_files: Option<usize>) -> Self {
+        Self::new(cache_dir, max_cached_files, |path| {
+            let file = BufReader::new(File::open(path)?);
+            Ok(Box::new(file))
+        })
+    }
+
+    pub fn from_mmap(cache_dir: &Path, max_cached_files: Option<usize>) -> Self {
+        Self::new(cache_dir, max_cached_files, |path| {
+            let file = File::open(path)?;
+            let mmap = Box::new(Cursor::new(unsafe { Mmap::map(&file) }?));
+            Ok(mmap)
+        })
     }
 
     pub fn fetch_unwind_info(
@@ -83,20 +112,18 @@ impl UnwindInfoManager {
         executable_id: ExecutableId,
         first_frame_override: Option<(u64, u64)>,
         check_digest: bool,
-    ) -> Result<Vec<CompactUnwindRow>, FetchUnwindInfoError> {
+    ) -> Result<Reader<impl Read + Seek>, FetchUnwindInfoError> {
         match self.read_from_cache(executable_id, check_digest) {
-            Ok(unwind_info) => Ok(unwind_info),
+            Ok(reader) => Ok(reader),
             Err(e) => {
-                if matches!(e, FetchUnwindInfoError::NotFound) {
-                    debug!("error fetch_unwind_info: {:?}, regenerating...", e);
-                }
                 // No matter the error, regenerate the unwind information.
-                let unwind_info =
-                    self.write_to_cache(executable_path, executable_id, first_frame_override);
-                if unwind_info.is_ok() {
-                    self.bump(executable_id, None);
-                }
-                unwind_info
+                debug!(
+                    "reading unwind info from cache failed with: {:?}, regenerating",
+                    e
+                );
+                self.write_to_cache(executable_path, executable_id, first_frame_override)?;
+                self.bump(executable_id, None);
+                self.read_from_cache(executable_id, check_digest)
             }
         }
     }
@@ -105,9 +132,9 @@ impl UnwindInfoManager {
         &self,
         executable_id: ExecutableId,
         check_digest: bool,
-    ) -> Result<Vec<CompactUnwindRow>, FetchUnwindInfoError> {
+    ) -> Result<Reader<impl Read + Seek>, FetchUnwindInfoError> {
         let unwind_info_path = self.path_for(executable_id);
-        let file = File::open(unwind_info_path).map_err(|e| {
+        let file = (self.file_opener)(&unwind_info_path).map_err(|e| {
             if e.kind() == ErrorKind::NotFound {
                 FetchUnwindInfoError::NotFound
             } else {
@@ -115,12 +142,12 @@ impl UnwindInfoManager {
             }
         })?;
 
-        let mut buffer = BufReader::new(file);
-        let mut data = Vec::new();
-        buffer.read_to_end(&mut data)?;
-        let reader = Reader::new(&data, check_digest).map_err(FetchUnwindInfoError::Reader)?;
+        let mut reader = Reader::new(file, check_digest).map_err(FetchUnwindInfoError::Reader)?;
+        if check_digest {
+            reader.check_digest()?;
+        }
 
-        Ok(reader.unwind_info()?)
+        Ok(reader)
     }
 
     fn write_to_cache(
@@ -128,7 +155,7 @@ impl UnwindInfoManager {
         executable_path: &Path,
         executable_id: ExecutableId,
         first_frame_override: Option<(u64, u64)>,
-    ) -> Result<Vec<CompactUnwindRow>, FetchUnwindInfoError> {
+    ) -> Result<(), FetchUnwindInfoError> {
         let unwind_info_path = self.path_for(executable_id);
         let unwind_info_writer = Writer::new(executable_path, first_frame_override);
         // [`File::create`] will truncate an existing file to the size it needs.
@@ -216,7 +243,7 @@ mod tests {
     fn test_unwind_info_manager_unwind_info() {
         let unwind_info = compact_unwind_info("/proc/self/exe", None).unwrap();
         let tmpdir = tempfile::TempDir::new().unwrap();
-        let mut manager = UnwindInfoManager::new(tmpdir.path(), None);
+        let mut manager = UnwindInfoManager::from_file(tmpdir.path(), None);
 
         // The unwind info fetched with the manager should be correct
         // both when it's a cache miss and a cache hit.
@@ -227,8 +254,8 @@ mod tests {
                 None,
                 true,
             );
-            let manager_unwind_info = manager_unwind_info.unwrap();
-            assert_eq!(unwind_info, manager_unwind_info);
+            let mut manager_unwind_info = manager_unwind_info.unwrap();
+            assert_eq!(unwind_info, manager_unwind_info.as_vec().unwrap());
         }
     }
 
@@ -236,7 +263,7 @@ mod tests {
     fn test_unwind_info_manager_corrupt() {
         let unwind_info = compact_unwind_info("/proc/self/exe", None).unwrap();
         let tmpdir = tempfile::TempDir::new().unwrap();
-        let mut manager = UnwindInfoManager::new(tmpdir.path(), None);
+        let mut manager = UnwindInfoManager::from_file(tmpdir.path(), None);
 
         // Cache unwind info.
         let manager_unwind_info = manager.fetch_unwind_info(
@@ -246,8 +273,8 @@ mod tests {
             true,
         );
         assert!(manager_unwind_info.is_ok());
-        let manager_unwind_info = manager_unwind_info.unwrap();
-        assert_eq!(unwind_info, manager_unwind_info);
+        let mut manager_unwind_info = manager_unwind_info.unwrap();
+        assert_eq!(unwind_info, manager_unwind_info.as_vec().unwrap());
 
         // Corrupt it.
         let mut file = OpenOptions::new()
@@ -264,7 +291,7 @@ mod tests {
             None,
             true,
         );
-        let manager_unwind_info = manager_unwind_info.unwrap();
+        let manager_unwind_info = manager_unwind_info.unwrap().as_vec().unwrap();
         assert_eq!(unwind_info, manager_unwind_info);
     }
 
@@ -279,7 +306,7 @@ mod tests {
         }
 
         assert_eq!(fs::read_dir(path).unwrap().collect::<Vec<_>>().len(), 20);
-        UnwindInfoManager::new(path, Some(4));
+        UnwindInfoManager::from_file(path, Some(4));
         assert_eq!(fs::read_dir(path).unwrap().collect::<Vec<_>>().len(), 4);
     }
 }

--- a/src/unwind_info/mod.rs
+++ b/src/unwind_info/mod.rs
@@ -3,6 +3,7 @@ pub mod manager;
 mod optimize;
 pub mod pages;
 pub mod persist;
+pub mod source;
 pub mod types;
 
 pub use convert::compact_unwind_info;

--- a/src/unwind_info/pages.rs
+++ b/src/unwind_info/pages.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::unwind_info::types::CompactUnwindRow;
+use crate::unwind_info::{persist::ReaderError, types::CompactUnwindRow};
 
 #[derive(PartialEq)]
 pub struct Page {
@@ -28,7 +28,10 @@ impl fmt::Debug for Page {
 /// unwind info in a given page in 16 iterations, and represent the program
 /// counters with 32 bits (32 bits for PC + 16 bits for page offset = 48 bits,
 /// which is enough as the upper 16 bits are unused).
-pub fn to_pages(unwind_info: &[CompactUnwindRow]) -> Vec<Page> {
+pub fn to_pages(
+    unwind_info: impl Iterator<Item = Result<CompactUnwindRow, ReaderError>>,
+    unwind_info_len: usize,
+) -> Result<Vec<Page>, ReaderError> {
     let page_size_bits = 16;
     let page_size = 2_u64.pow(page_size_bits);
     let low_bits_mask = page_size - 1;
@@ -38,7 +41,8 @@ pub fn to_pages(unwind_info: &[CompactUnwindRow]) -> Vec<Page> {
     let mut prev_high_pc = None;
     let mut prev_index = 0;
 
-    for (i, row) in unwind_info.iter().enumerate() {
+    for (i, row) in unwind_info.into_iter().enumerate() {
+        let row = row?;
         let high_pc = row.pc & high_bits_mask;
         match prev_high_pc {
             None => {
@@ -78,11 +82,11 @@ pub fn to_pages(unwind_info: &[CompactUnwindRow]) -> Vec<Page> {
         pages.push(Page {
             address: id,
             low_index: prev_index.try_into().unwrap(),
-            high_index: unwind_info.len().try_into().unwrap(),
+            high_index: unwind_info_len.try_into().unwrap(),
         });
     }
 
-    pages
+    Ok(pages)
 }
 
 #[cfg(test)]
@@ -92,12 +96,17 @@ mod tests {
     #[test]
     fn test_to_pages() {
         let unwind_info = vec![];
-        let pages = to_pages(&unwind_info);
+        let pages = to_pages(unwind_info.clone().into_iter(), 0).unwrap();
         assert_eq!(pages, vec![]);
 
         let row = CompactUnwindRow::default();
-        let unwind_info = vec![CompactUnwindRow { pc: 0x100, ..row }];
-        let pages = to_pages(&unwind_info);
+        let unwind_info = vec![CompactUnwindRow { pc: 0x100, ..row }]
+            .into_iter()
+            .map(Ok)
+            .collect::<Vec<_>>();
+
+        let len = unwind_info.len();
+        let pages = to_pages(unwind_info.clone().into_iter(), len).unwrap();
         assert_eq!(
             pages,
             vec![Page {
@@ -121,10 +130,15 @@ mod tests {
                 pc: 0x1103f4,
                 ..row
             },
-        ];
-        let pages = to_pages(&unwind_info);
+        ]
+        .into_iter()
+        .map(Ok)
+        .collect::<Vec<_>>();
+
+        let len = unwind_info.len();
+        let pages = to_pages(unwind_info.clone().into_iter(), len).unwrap();
         assert!(
-            unwind_info.is_sorted_by(|a, b| a.pc <= b.pc),
+            unwind_info.is_sorted_by(|a, b| a.as_ref().unwrap().pc <= b.as_ref().unwrap().pc),
             "unwind info is sorted"
         );
         assert_eq!(
@@ -158,8 +172,13 @@ mod tests {
                 pc: 4 * 2_u64.pow(16),
                 ..row
             },
-        ];
-        let pages = to_pages(&unwind_info);
+        ]
+        .into_iter()
+        .map(Ok)
+        .collect::<Vec<_>>();
+
+        let len = unwind_info.len();
+        let pages = to_pages(unwind_info.clone().into_iter(), len).unwrap();
         assert_eq!(
             pages,
             vec![
@@ -195,9 +214,10 @@ mod tests {
         let page_size_bits = 16;
         let low_bits_mask = u64::pow(2, page_size_bits) - 1;
         let high_bits_mask = u64::MAX ^ low_bits_mask;
-        let pages = to_pages(&unwind_info);
-
+        let len = unwind_info.len();
+        let pages = to_pages(unwind_info.clone().into_iter(), len).unwrap();
         for row in &unwind_info {
+            let row = row.as_ref().unwrap();
             let pc = row.pc;
             let pc_high = pc & high_bits_mask;
             assert_eq!(pc_high, pc_high & 0x0000FFFFFFFF0000); // [ 16 unused bits -- 32 bits for high -- 16 bits for each page ]
@@ -205,9 +225,12 @@ mod tests {
             let found = pages.iter().find(|el| el.address == pc_high).unwrap();
             // Make sure we can find the inner slice
             let search_here = &unwind_info[(found.low_index as usize)..(found.high_index as usize)];
-            let found_row = search_here.iter().find(|el| el.pc == pc).unwrap();
+            let found_row = search_here
+                .iter()
+                .find(|el| el.as_ref().unwrap().pc == pc)
+                .unwrap();
             // And that the high and low bits were done ok
-            let pc = found_row.pc;
+            let pc = found_row.as_ref().unwrap().pc;
             assert_eq!((pc & low_bits_mask) + pc_high, pc);
         }
     }

--- a/src/unwind_info/persist.rs
+++ b/src/unwind_info/persist.rs
@@ -1,9 +1,11 @@
+use std::cell::RefCell;
 use std::io::Read;
 use std::io::Seek;
 use std::io::SeekFrom;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
+use std::rc::Rc;
 
 use plain::Plain;
 use ring::digest::{Context, SHA256};
@@ -62,10 +64,7 @@ impl Writer {
         }
     }
 
-    pub fn write<W: Write + Seek>(
-        self,
-        writer: &mut W,
-    ) -> Result<Vec<CompactUnwindRow>, WriterError> {
+    pub fn write<W: Write + Seek>(self, writer: &mut W) -> Result<(), WriterError> {
         let unwind_info = self.read_unwind_info(self.first_frame_override)?;
         // Write dummy header.
         self.write_header(writer, 0, None)?;
@@ -73,7 +72,8 @@ impl Writer {
         // Write real header.
         writer.seek(SeekFrom::Start(0))?;
         self.write_header(writer, unwind_info.len(), Some(digest))?;
-        Ok(unwind_info)
+
+        Ok(())
     }
 
     fn read_unwind_info(
@@ -125,7 +125,7 @@ impl Writer {
     }
 }
 
-#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq, Clone)]
 pub enum ReaderError {
     #[error("magic number does not match")]
     MagicNumber,
@@ -140,29 +140,165 @@ pub enum ReaderError {
     #[error("digest does not match")]
     Digest,
 }
-
-/// Reads compact information of a bytes slice.
-pub struct Reader<'a> {
+/// Reads compact information.
+pub struct Reader<R: Read + Seek> {
     header: Header,
-    data: &'a [u8],
+    reader: Rc<RefCell<R>>,
     check_digest: bool,
+    first_row: Option<CompactUnwindRow>,
+    last_row: Option<CompactUnwindRow>,
 }
 
-impl<'a> Reader<'a> {
-    pub fn new(data: &'a [u8], check_digest: bool) -> Result<Self, ReaderError> {
-        let header = Self::parse_header(data)?;
+pub struct CompactUnwindRowIter<R: Read> {
+    reader: Rc<RefCell<R>>,
+    /// Current index for iterator.
+    index: u64,
+    /// Total number of items in iterator.
+    size: u64,
+    check_digest: bool,
+    unwind_info_digest: UnwindInformationDigest,
+    context: Context,
+    unwind_row_data: Vec<u8>,
+}
+
+impl<R: Read> CompactUnwindRowIter<R> {
+    /// Checks if the digest of the persisted unwind information is correct.
+    ///
+    /// Note: this must be called once the iterator is fully consumed.
+    fn check_digest(&self) -> Result<(), ReaderError> {
+        if !self.check_digest {
+            return Ok(());
+        }
+
+        let mut buffer = [0; 8];
+        self.context
+            .clone()
+            .finish()
+            .as_ref()
+            .read(&mut buffer)
+            .map_err(|e| ReaderError::Generic(e.to_string()))?;
+        let digest = u64::from_ne_bytes(buffer);
+
+        if self.unwind_info_digest != digest {
+            return Err(ReaderError::Digest);
+        }
+
+        Ok(())
+    }
+}
+
+impl<R: Read + Seek> Iterator for CompactUnwindRowIter<R> {
+    type Item = Result<CompactUnwindRow, ReaderError>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.size {
+            return None;
+        }
+
+        let mut reader = self.reader.borrow_mut();
+        let read_result = read_compact_row_at(&mut *reader, None, &mut self.unwind_row_data);
+        let Ok(unwind_row) = read_result else {
+            self.index += 1;
+            return Some(read_result);
+        };
+
+        if self.check_digest {
+            self.context.update(&self.unwind_row_data);
+        }
+
+        self.index += 1;
+        Some(Ok(unwind_row))
+    }
+}
+
+/// Reads a single [`CompactUnwindRow`] from [`reader`] at position [`index`],
+/// if specified. Otherwise it will read from the current reader's position.
+/// After returning, the reader will point at the next element to be read.
+#[inline(always)]
+fn read_compact_row_at<R: Read + Seek>(
+    reader: &mut R,
+    index: Option<u64>,
+    unwind_row_buffer: &mut [u8],
+) -> Result<CompactUnwindRow, ReaderError> {
+    let mut unwind_row = CompactUnwindRow::default();
+    if let Some(index) = index {
+        reader
+            .seek(SeekFrom::Start(
+                std::mem::size_of::<Header>() as u64
+                    + index * std::mem::size_of::<CompactUnwindRow>() as u64,
+            ))
+            .map_err(|e| ReaderError::Generic(format!("Failed to seek: {:?}", e)))?;
+    }
+
+    if reader.read_exact(unwind_row_buffer).is_err() {
+        return Err(ReaderError::OutOfRange);
+    };
+
+    if let Err(e) = plain::copy_from_bytes(&mut unwind_row, unwind_row_buffer) {
+        return Err(ReaderError::Generic(format!("{e:?}")));
+    };
+
+    Ok(unwind_row)
+}
+
+/// Reads persisted compact unwind information. Unless `check_digest` is
+/// specified, the unwind information integrity won't be verified.
+impl<R: Read + Seek> Reader<R> {
+    pub fn new(mut reader: R, check_digest: bool) -> Result<Self, ReaderError> {
+        let header = Self::parse_header(&mut reader)?;
+        let mut row_buffer = vec![0; std::mem::size_of::<CompactUnwindRow>()];
+        let first_row = read_compact_row_at(&mut reader, Some(0), &mut row_buffer).ok();
+        let last_row = if header.unwind_info_len > 0 {
+            read_compact_row_at(
+                &mut reader,
+                Some(header.unwind_info_len - 1),
+                &mut row_buffer,
+            )
+            .ok()
+        } else {
+            None
+        };
+
         Ok(Reader {
             header,
-            data,
+            reader: Rc::new(RefCell::new(reader)),
             check_digest,
+            first_row,
+            last_row,
         })
     }
 
-    fn parse_header(data: &[u8]) -> Result<Header, ReaderError> {
+    /// Returns the first compact unwind information entry, if it exists.
+    pub fn first(&self) -> Option<CompactUnwindRow> {
+        self.first_row
+    }
+
+    /// Returns the last compact unwind information entry, if it exists.
+    pub fn last(&self) -> Option<CompactUnwindRow> {
+        self.last_row
+    }
+
+    /// Returns the number of compact unwind information entries that the header
+    /// specified.
+    pub fn len(&self) -> usize {
+        self.header.unwind_info_len as usize
+    }
+
+    /// Returns whether there compact unwind information entries.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Parses the header of the compact unwind information entries persisted
+    /// format.
+    fn parse_header(data: &mut R) -> Result<Header, ReaderError> {
         let header_size = std::mem::size_of::<Header>();
         let mut header = Header::default();
-        let header_data = data.get(0..header_size).ok_or(ReaderError::OutOfRange)?;
-        plain::copy_from_bytes(&mut header, header_data)
+        let mut header_data = vec![0; header_size];
+        data.read_exact(&mut header_data)
+            .map_err(|_| ReaderError::OutOfRange)?;
+        plain::copy_from_bytes(&mut header, &header_data)
             .map_err(|e| ReaderError::Generic(format!("{e:?}")))?;
 
         if header.magic != MAGIC_NUMBER {
@@ -176,8 +312,74 @@ impl<'a> Reader<'a> {
         Ok(header)
     }
 
-    pub fn unwind_info(self) -> Result<Vec<CompactUnwindRow>, ReaderError> {
+    /// Iterates through the compact unwind information entries and verifies its
+    /// integrity.
+    pub fn check_digest(&mut self) -> Result<(), ReaderError> {
+        let mut iter = self.iter();
+        for row in &mut iter {
+            row?;
+        }
+        iter.check_digest()
+    }
+
+    /// Returns a compact unwind information iterator resetting the iterator to
+    /// first entry to be read.
+    ///
+    /// Note that this iterator deviates
+    /// from the convention of having `iter` to return an iterator that on calls
+    /// to the `next` method return a reference to each item and instead
+    /// returns owned items.
+    pub fn iter(&mut self) -> CompactUnwindRowIter<R> {
+        let reader = self.reader.clone();
+        // Set reader past the header, since there could be multiple calls
+        // to this method across the code.
+        reader
+            .borrow_mut()
+            .seek(SeekFrom::Start(std::mem::size_of::<Header>() as u64))
+            .expect("Failed to seek");
+
+        CompactUnwindRowIter {
+            context: Context::new(&SHA256),
+            unwind_info_digest: self.header.unwind_info_digest,
+            check_digest: self.check_digest,
+            reader,
+            index: 0,
+            size: self.header.unwind_info_len,
+            unwind_row_data: vec![0; std::mem::size_of::<CompactUnwindRow>()],
+        }
+    }
+
+    /// Returns the compact unwind information in an in-memory vector.
+    pub fn as_vec(&mut self) -> Result<Vec<CompactUnwindRow>, ReaderError> {
+        let mut unwind_info = Vec::with_capacity(self.header.unwind_info_len as usize);
+        let mut iter = self.iter();
+        for row in &mut iter {
+            unwind_info.push(row?);
+        }
+
+        iter.check_digest()?;
+
+        Ok(unwind_info)
+    }
+
+    #[allow(dead_code)]
+    #[deprecated(note = "Use as_vec() or the iterator directly.")]
+    pub fn as_vec_no_iter(self) -> Result<Vec<CompactUnwindRow>, ReaderError> {
         let header_size = std::mem::size_of::<Header>();
+        let mut data = Vec::new();
+        // Reader points past the header
+        self.reader
+            .borrow_mut()
+            .seek(SeekFrom::Start(
+                header_size
+                    .try_into()
+                    .expect("Could not convert header size"),
+            ))
+            .expect("Failed to seek");
+        self.reader
+            .borrow_mut()
+            .read_to_end(&mut data)
+            .expect("error reading unwind information");
         let unwind_row_size = std::mem::size_of::<CompactUnwindRow>();
         let unwind_info_len: usize = self
             .header
@@ -188,7 +390,7 @@ impl<'a> Reader<'a> {
         let mut unwind_info = Vec::with_capacity(unwind_info_len);
         let mut unwind_row = CompactUnwindRow::default();
 
-        let unwind_info_data = &self.data[header_size..];
+        let unwind_info_data = &data[..];
         let mut context = Context::new(&SHA256);
         for i in 0..unwind_info_len {
             let step = i * unwind_row_size;
@@ -226,7 +428,67 @@ mod tests {
     use std::io::Cursor;
     use std::path::PathBuf;
 
+    use crate::unwind_info::types::CfaType::FramePointerOffset;
+    use crate::unwind_info::types::RbpType::UndefinedReturnAddress;
+
     use super::*;
+
+    #[test]
+    fn test_info_reader_without_entries_works() {
+        let mut buffer = Cursor::new(Vec::new());
+        let header = Header {
+            version: VERSION,
+            magic: MAGIC_NUMBER,
+            unwind_info_len: 0,
+            unwind_info_digest: 0x0,
+        };
+        buffer
+            .write_all(unsafe { plain::as_bytes(&header) })
+            .unwrap();
+
+        buffer.seek(SeekFrom::Start(0)).unwrap();
+        let mut reader = Reader::new(&mut buffer, true).unwrap();
+
+        assert!(reader.first().is_none());
+        assert!(reader.last().is_none());
+        assert_eq!(reader.len(), 0);
+        assert!(reader.is_empty());
+        assert_eq!(reader.iter().collect::<Vec<_>>(), vec![]);
+    }
+
+    #[test]
+    fn test_info_reader_with_entries_works() {
+        let mut buffer = Cursor::new(Vec::new());
+        let header = Header {
+            version: VERSION,
+            magic: MAGIC_NUMBER,
+            unwind_info_len: 1,
+            unwind_info_digest: 0x0,
+        };
+        buffer
+            .write_all(unsafe { plain::as_bytes(&header) })
+            .unwrap();
+
+        let row = CompactUnwindRow {
+            pc: 0x42,
+            cfa_type: FramePointerOffset,
+            rbp_type: UndefinedReturnAddress,
+            cfa_offset: 0x35,
+            rbp_offset: 0x82,
+        };
+        buffer.write_all(unsafe { plain::as_bytes(&row) }).unwrap();
+
+        buffer.seek(SeekFrom::Start(0)).unwrap();
+        let mut reader = Reader::new(&mut buffer, true).unwrap();
+
+        assert_eq!(reader.first(), Some(row));
+        assert_eq!(reader.last(), Some(row));
+        assert_eq!(reader.len(), 1);
+        assert!(!reader.is_empty());
+        assert_eq!(reader.iter().collect::<Vec<_>>(), vec![Ok(row)]);
+        // Call iterator again to ensure that the writer's position is properly reset
+        assert_eq!(reader.iter().collect::<Vec<_>>(), vec![Ok(row)]);
+    }
 
     #[test]
     fn test_write_and_read_unwind_info() {
@@ -235,10 +497,18 @@ mod tests {
         let writer = Writer::new(&path, None);
         assert!(writer.write(&mut buffer).is_ok());
 
-        let reader = Reader::new(&buffer.get_ref()[..], true);
-        let unwind_info = reader.unwrap().unwind_info();
-        assert!(unwind_info.is_ok());
-        let unwind_info = unwind_info.unwrap();
+        buffer.seek(SeekFrom::Start(0)).unwrap();
+        let mut reader = Reader::new(buffer, true);
+        assert!(reader.is_ok());
+
+        let unwind_info = reader.as_mut().unwrap().as_vec().unwrap();
+        assert_eq!(
+            unwind_info,
+            compact_unwind_info("/proc/self/exe", None).unwrap()
+        );
+
+        // Exercise the reader state reset logic again.
+        let unwind_info = reader.unwrap().as_vec().unwrap();
         assert_eq!(
             unwind_info,
             compact_unwind_info("/proc/self/exe", None).unwrap()
@@ -247,7 +517,7 @@ mod tests {
 
     #[test]
     fn test_bad_magic() {
-        let mut buffer = Vec::new();
+        let mut buffer = Cursor::new(Vec::new());
         let header = Header {
             magic: 0xBAD,
             ..Default::default()
@@ -255,15 +525,17 @@ mod tests {
         buffer
             .write_all(unsafe { plain::as_bytes(&header) })
             .unwrap();
+
+        buffer.seek(SeekFrom::Start(0)).unwrap();
         assert!(matches!(
-            Reader::new(&buffer, true),
+            Reader::new(buffer, true),
             Err(ReaderError::MagicNumber)
         ));
     }
 
     #[test]
     fn test_version_mismatch() {
-        let mut buffer = Vec::new();
+        let mut buffer = Cursor::new(Vec::new());
         let header = Header {
             version: VERSION + 1,
             magic: MAGIC_NUMBER,
@@ -272,8 +544,9 @@ mod tests {
         buffer
             .write_all(unsafe { plain::as_bytes(&header) })
             .unwrap();
+        buffer.seek(SeekFrom::Start(0)).unwrap();
         assert!(matches!(
-            Reader::new(&buffer, true),
+            Reader::new(buffer, true),
             Err(ReaderError::Version)
         ));
     }
@@ -288,28 +561,28 @@ mod tests {
         // Corrupt unwind info.
         buffer.seek(SeekFrom::End(-10)).unwrap();
         buffer.write_all(&[0, 0, 0, 0, 0, 0, 0]).unwrap();
+        buffer.seek(SeekFrom::Start(0)).unwrap();
 
-        let reader = Reader::new(&buffer.get_ref()[..], true);
-        let unwind_info = reader.unwrap().unwind_info();
-        assert!(matches!(unwind_info, Err(ReaderError::Digest)));
+        let reader = Reader::new(buffer.clone(), true).unwrap().as_vec();
+        assert!(matches!(reader, Err(ReaderError::Digest)));
 
-        let reader = Reader::new(&buffer.get_ref()[..], false);
-        let unwind_info = reader.unwrap().unwind_info();
+        let reader = Reader::new(buffer, false);
+        let unwind_info = reader.unwrap().as_vec();
         assert!(unwind_info.is_ok());
     }
 
     #[test]
     fn test_header_too_small() {
-        let buffer = Vec::new();
+        let buffer = Cursor::new(Vec::new());
         assert!(matches!(
-            Reader::new(&buffer, true),
+            Reader::new(buffer, true),
             Err(ReaderError::OutOfRange)
         ));
     }
 
     #[test]
     fn test_unwind_info_too_small() {
-        let mut buffer = Vec::new();
+        let mut buffer = Cursor::new(Vec::new());
         let header = Header {
             version: VERSION,
             magic: MAGIC_NUMBER,
@@ -319,8 +592,9 @@ mod tests {
         buffer
             .write_all(unsafe { plain::as_bytes(&header) })
             .unwrap();
+        buffer.seek(SeekFrom::Start(0)).unwrap();
         assert!(matches!(
-            Reader::new(&buffer, true).unwrap().unwind_info(),
+            Reader::new(&mut buffer, true).unwrap().as_vec(),
             Err(ReaderError::OutOfRange)
         ));
     }

--- a/src/unwind_info/source.rs
+++ b/src/unwind_info/source.rs
@@ -1,0 +1,44 @@
+use crate::unwind_info::persist::Reader;
+use crate::unwind_info::persist::ReaderError;
+use crate::unwind_info::types::CompactUnwindRow;
+use std::io::Read;
+use std::io::Seek;
+
+pub enum UnwindInfoSource<R: Read + Seek> {
+    Vector(Vec<CompactUnwindRow>),
+    Reader(Reader<R>),
+}
+
+impl<R: Read + Seek + 'static> UnwindInfoSource<R> {
+    pub fn len(&self) -> usize {
+        match self {
+            UnwindInfoSource::Vector(vec) => vec.len(),
+            UnwindInfoSource::Reader(reader) => reader.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn first(&mut self) -> Option<CompactUnwindRow> {
+        match self {
+            UnwindInfoSource::Vector(vec) => vec.first().copied(),
+            UnwindInfoSource::Reader(reader) => reader.first(),
+        }
+    }
+
+    pub fn last(&mut self) -> Option<CompactUnwindRow> {
+        match self {
+            UnwindInfoSource::Vector(vec) => vec.last().copied(),
+            UnwindInfoSource::Reader(reader) => reader.last(),
+        }
+    }
+
+    pub fn iter(&mut self) -> Box<dyn Iterator<Item = Result<CompactUnwindRow, ReaderError>>> {
+        match self {
+            UnwindInfoSource::Vector(vec) => Box::new(vec.clone().into_iter().map(Ok)),
+            UnwindInfoSource::Reader(ref mut reader) => Box::new(reader.iter()),
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an iterator for the persisted unwind information to avoid having to keep it all in memory. It's almost ready for review but needs a bit more love in terms of error handling (no new unwraps!), more manual testing, as well as documentation.

Any early feedback is greatly appreciated! 