### PR TITLE
Remove event loop timeout

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -558,7 +558,6 @@ impl Profiler {
                             }
                         }
                     },
-                default(Duration::from_millis(100)) => {},
             }
         }
 


### PR DESCRIPTION
This unnecessarily wakes up the main thread 10 times a second.

Test Plan
=========

CI and local testing to ensure that other events are delivered in the absense of a timeout