### PR TITLE
Read process name in BPF

### DIFF
--- a/lightswitch-metadata/src/metadata_provider.rs
+++ b/lightswitch-metadata/src/metadata_provider.rs
@@ -115,7 +115,7 @@ impl GlobalMetadataProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::taskname::TaskName;
+    use crate::taskname::ThreadInfo;
     use crate::types::MetadataLabelValue;
     use nix::unistd;
 
@@ -125,31 +125,26 @@ mod tests {
         let tid = unistd::gettid().as_raw();
         let pid = unistd::getpgrp().as_raw();
         let mut metadata_provider = GlobalMetadataProvider::default();
-        let expected = TaskName::for_task(tid).unwrap();
+        let expected = ThreadInfo::for_task(tid).unwrap().comm;
 
         // When
         let labels = metadata_provider.get_metadata(TaskKey { tid, pid });
 
         // Then
-        assert_eq!(labels[0].key, "pid");
+        assert_eq!(labels[0].key, "tid");
         assert_eq!(
             labels[0].value,
-            MetadataLabelValue::Number(tid.into(), "task-id".into())
+            MetadataLabelValue::Number(tid.into(), "".into())
         );
         assert_eq!(labels[1].key, "thread.name");
         assert_eq!(
             labels[1].value,
-            MetadataLabelValue::String(expected.current_thread)
+            MetadataLabelValue::String(expected.clone())
         );
-        assert_eq!(labels[2].key, "process.name");
+        assert_eq!(labels[2].key, "pid");
         assert_eq!(
             labels[2].value,
-            MetadataLabelValue::String(expected.main_thread)
-        );
-        assert_eq!(labels[3].key, "pid");
-        assert_eq!(
-            labels[3].value,
-            MetadataLabelValue::Number(pid.into(), "task-tgid".into())
+            MetadataLabelValue::Number(pid.into(), "".into())
         );
     }
 }

--- a/lightswitch-metadata/src/task_metadata.rs
+++ b/lightswitch-metadata/src/task_metadata.rs
@@ -1,5 +1,8 @@
-use crate::taskname::TaskName;
+use crate::taskname::ThreadInfo;
 use crate::types::{MetadataLabel, TaskKey, TaskMetadataProvider, TaskMetadataProviderError};
+
+pub const PROCESS_NAME_KEY: &str = "process.name";
+pub const THREAD_NAME_KEY: &str = "thread.name";
 
 pub struct TaskMetadata {}
 
@@ -8,13 +11,12 @@ impl TaskMetadataProvider for TaskMetadata {
         &self,
         task_key: TaskKey,
     ) -> Result<Vec<MetadataLabel>, TaskMetadataProviderError> {
-        let task_name = TaskName::for_task(task_key.tid).unwrap_or(TaskName::errored());
+        let thread_info = ThreadInfo::for_task(task_key.tid).unwrap_or(ThreadInfo::errored());
         let pid = task_key.pid;
         Ok(vec![
-            MetadataLabel::from_number_value("pid".into(), task_key.tid.into(), "task-id".into()),
-            MetadataLabel::from_string_value("thread.name".into(), task_name.current_thread),
-            MetadataLabel::from_string_value("process.name".into(), task_name.main_thread),
-            MetadataLabel::from_number_value("pid".into(), pid.into(), "task-tgid".into()),
+            MetadataLabel::from_number_value("tid".into(), task_key.tid.into(), "".into()),
+            MetadataLabel::from_string_value(THREAD_NAME_KEY.into(), thread_info.comm),
+            MetadataLabel::from_number_value("pid".into(), pid.into(), "".into()),
         ])
     }
 }

--- a/lightswitch-metadata/src/taskname.rs
+++ b/lightswitch-metadata/src/taskname.rs
@@ -1,28 +1,23 @@
 #[derive(Debug, PartialEq, Eq)]
-pub struct TaskName {
-    pub main_thread: String,
-    pub current_thread: String,
+pub struct ThreadInfo {
+    pub main_thread: bool,
+    pub comm: String,
 }
 
-impl TaskName {
+impl ThreadInfo {
     pub fn errored() -> Self {
-        TaskName {
-            main_thread: "<could not fetch process name>".into(),
-            current_thread: "<could not fetch thread name>".into(),
+        ThreadInfo {
+            main_thread: false,
+            comm: "<could not fetch thread name>".into(),
         }
     }
 
-    pub fn for_task(task_id: i32) -> Result<TaskName, anyhow::Error> {
+    pub fn for_task(task_id: i32) -> Result<ThreadInfo, anyhow::Error> {
         let task = procfs::process::Process::new(task_id)?;
         let main_task = procfs::process::Process::new(task.status()?.tgid)?.stat()?;
-        let thread_name = if task.pid == main_task.pid {
-            "<main thread>".to_string()
-        } else {
-            task.stat()?.comm
-        };
-        Ok(TaskName {
-            main_thread: main_task.comm,
-            current_thread: thread_name,
+        Ok(ThreadInfo {
+            main_thread: task.pid == main_task.pid,
+            comm: task.stat()?.comm,
         })
     }
 }
@@ -35,16 +30,19 @@ mod tests {
 
     #[test]
     fn test_thread_name() {
-        let names =
-            TaskName::for_task(unistd::getpgid(Some(unistd::getpid())).unwrap().as_raw()).unwrap();
-        assert_eq!(names.current_thread, "<main thread>");
+        let current_thread = ThreadInfo::for_task(unistd::getpid().as_raw())
+            .unwrap()
+            .comm;
+        assert_eq!(current_thread, "lightswitch_met");
 
         let builder = thread::Builder::new().name("funky-thread-name".to_string());
 
         builder
             .spawn(|| {
-                let names = TaskName::for_task(unistd::gettid().as_raw()).unwrap();
-                assert_eq!(names.current_thread, "funky-thread-na");
+                let current_thread = ThreadInfo::for_task(unistd::gettid().as_raw())
+                    .unwrap()
+                    .comm;
+                assert_eq!(current_thread, "funky-thread-na");
             })
             .unwrap()
             .join()
@@ -54,16 +52,12 @@ mod tests {
     #[test]
     fn test_errored() {
         // Given
-        let task_name = TaskName::errored();
+        let task_name = ThreadInfo::errored();
 
         // When / Then
         assert_eq!(
-            task_name.current_thread,
+            task_name.comm,
             String::from("<could not fetch thread name>")
-        );
-        assert_eq!(
-            task_name.main_thread,
-            String::from("<could not fetch process name>")
         );
     }
 }

--- a/src/bpf/profiler.bpf.c
+++ b/src/bpf/profiler.bpf.c
@@ -68,7 +68,7 @@ struct {
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(max_entries, MAX_PROCESSES);
-    __type(key, Event);
+    __type(key, u64);
     __type(value, bool);
 } rate_limits SEC(".maps");
 
@@ -136,7 +136,8 @@ find_page(mapping_t *mapping, u64 object_relative_pc, u64 *low_index, u64 *high_
 }
 
 static __always_inline void send_event(Event *event, struct bpf_perf_event_data *ctx) {
-    bool *is_rate_limited = bpf_map_lookup_elem(&rate_limits, event);
+    u64 event_id = ((u64)event->pid << 32 | event->type);
+    bool *is_rate_limited = bpf_map_lookup_elem(&rate_limits, &event_id);
     if (is_rate_limited != NULL && *is_rate_limited) {
         LOG("[debug] send_event was rate limited for process %d", event->pid);
         return;
@@ -161,7 +162,7 @@ static __always_inline void send_event(Event *event, struct bpf_perf_event_data 
     LOG("[debug] event type %d sent for process %d", event->type, event->pid);
     bool rate_limited = true;
 
-    bpf_map_update_elem(&rate_limits, event, &rate_limited, BPF_ANY);
+    bpf_map_update_elem(&rate_limits, &event_id, &rate_limited, BPF_ANY);
 }
 
 // The return address points as the the instruction at which execution
@@ -662,6 +663,8 @@ int on_event(struct bpf_perf_event_data *ctx) {
         .type = EVENT_NEW_PROCESS,
         .pid = per_process_id,
     };
+    // Send the main thread's name.
+    BPF_CORE_READ_STR_INTO(&event.comm, task, group_leader, comm);
     send_event(&event, ctx);
     return 0;
 }

--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -190,6 +190,8 @@ typedef struct {
     enum event_type type;
     int pid;  // use right name here (tgid?)
     u64 address;
+    // Not using char as it's signed in arm64.
+    u8 comm[16];
 } Event;
 
 enum program {

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -324,6 +324,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     match args.profile_format {
         ProfileFormat::FlameGraph => {
             let folded = fold_profile(
+                procs,
                 profile,
                 args.flamegraph_aggregation == FlamegraphAggregation::Function,
             );

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -419,7 +419,7 @@ impl Collector for LiveCollector {
 
         let profile = raw_to_processed(&raw_profile, procs, objs);
         let profile = symbolize_profile(&profile, procs, objs);
-        let folded = fold_profile(profile, true);
+        let folded = fold_profile(procs, profile, true);
 
         if !folded.trim().is_empty() {
             let _ = self.tx.send(folded);

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Instant;
-
 use tracing::debug;
 
 use lightswitch_object::BuildId;
@@ -31,6 +30,7 @@ pub enum ProcessStatus {
 
 #[derive(Debug, Clone)]
 pub struct ProcessInfo {
+    pub comm: String,
     pub status: ProcessStatus,
     pub mappings: ExecutableMappings,
     pub last_used: Instant,

--- a/src/profile/convert.rs
+++ b/src/profile/convert.rs
@@ -1,6 +1,7 @@
 use lightswitch_metadata::metadata_provider::ThreadSafeGlobalMetadataProvider;
-use lightswitch_metadata::taskname::TaskName;
-use lightswitch_metadata::types::{MetadataLabelValue, TaskKey};
+use lightswitch_metadata::task_metadata::PROCESS_NAME_KEY;
+use lightswitch_metadata::taskname::ThreadInfo;
+use lightswitch_metadata::types::{MetadataLabel, MetadataLabelValue, TaskKey};
 
 use lightswitch_proto::profile::pprof::Label;
 use lightswitch_proto::profile::{pprof, LabelStringOrNumber, PprofBuilder};
@@ -192,10 +193,19 @@ pub fn to_pprof(
             tid: sample.tid,
             pid: sample.pid,
         };
+
+        let Some(info) = procs.get(&sample.pid) else {
+            // todo: maybe append an error frame for debugging?
+            continue;
+        };
         let labels = task_to_labels.entry(task_key).or_insert_with(|| {
             let metadata = metadata_provider.lock().unwrap().get_metadata(task_key);
             metadata
                 .into_iter()
+                .chain(vec![MetadataLabel::from_string_value(
+                    PROCESS_NAME_KEY.into(),
+                    info.comm.clone(),
+                )])
                 .map(|label| {
                     pprof.new_label(&label.key, ProfileLabel { value: label.value }.into())
                 })
@@ -217,7 +227,11 @@ pub fn to_pprof(
 /// The frame names are separated by semicolons and the count is at the end
 /// separated with a space. We insert some synthetic frames to quickly identify
 /// the thread and process names and other pieces of metadata.
-pub fn fold_profile(profile: AggregatedProfile, only_show_function_names: bool) -> String {
+pub fn fold_profile(
+    procs: &HashMap<i32, ProcessInfo>,
+    profile: AggregatedProfile,
+    only_show_function_names: bool,
+) -> String {
     let mut folded = String::new();
 
     for sample in profile {
@@ -239,13 +253,20 @@ pub fn fold_profile(profile: AggregatedProfile, only_show_function_names: bool) 
         let kstack = kstack.join(";");
         let count: String = sample.count.to_string();
 
-        let task_and_process_names = TaskName::for_task(sample.tid).unwrap_or(TaskName::errored());
+        let process_name = match procs.get(&sample.pid) {
+            Some(sample) => sample.comm.clone(),
+            None => "<process not known>".into(),
+        };
+
+        let thread_name = ThreadInfo::for_task(sample.tid)
+            .unwrap_or(ThreadInfo::errored())
+            .comm;
 
         writeln!(
             folded,
             "{};{}{}{} {}",
-            task_and_process_names.main_thread,
-            task_and_process_names.current_thread,
+            process_name,
+            thread_name,
             if ustack.trim().is_empty() {
                 "".to_string()
             } else {

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -20,6 +20,7 @@ use parking_lot::RwLock;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::env::temp_dir;
+use std::ffi::CStr;
 use std::fs;
 use std::fs::read_link;
 use std::fs::File;
@@ -370,6 +371,7 @@ impl Profiler {
                 self.procs.write().insert(
                     KERNEL_PID,
                     ProcessInfo {
+                        comm: "kernel".to_string(),
                         status: ProcessStatus::Running,
                         mappings: ExecutableMappings(
                             kernel_code_ranges
@@ -543,7 +545,11 @@ impl Profiler {
                 recv(self.new_proc_chan_receive) -> read => {
                         if let Ok(event) = read {
                             if event.type_ == event_type_EVENT_NEW_PROCESS {
-                                self.event_new_proc(event.pid);
+                                let comm = match CStr::from_bytes_until_nul(&event.comm) {
+                                    Ok(comm) => comm.to_string_lossy().to_string(),
+                                    Err(e) => format!("failed with get process name with `{e}`")
+                                };
+                                self.event_new_proc(event.pid, comm);
                                 // Ensure we only remove the rate limits only if the above works.
                                 // This is probably suited for a batched operation.
                                 // let _ = self
@@ -1104,7 +1110,7 @@ impl Profiler {
         self.filter_pids.contains_key(&pid)
     }
 
-    fn event_new_proc(&mut self, pid: Pid) {
+    fn event_new_proc(&mut self, pid: Pid, comm: String) {
         if !self.should_profile(pid) {
             return;
         }
@@ -1116,7 +1122,7 @@ impl Profiler {
             return;
         }
 
-        match self.add_proc(pid) {
+        match self.add_proc(pid, comm) {
             Ok(()) => {
                 self.add_unwind_info_for_process(pid);
             }
@@ -1316,7 +1322,7 @@ impl Profiler {
         info
     }
 
-    pub fn add_proc(&mut self, pid: Pid) -> Result<(), AddProcessError> {
+    pub fn add_proc(&mut self, pid: Pid, comm: String) -> Result<(), AddProcessError> {
         let proc = procfs::process::Process::new(pid).map_err(|_| AddProcessError::ProcfsRace)?;
         let maps = proc.maps().map_err(|_| AddProcessError::ProcfsRace)?;
         if !self.maybe_evict_process(true) {
@@ -1449,6 +1455,7 @@ impl Profiler {
         }
 
         let proc_info = ProcessInfo {
+            comm: comm.to_owned(),
             status: ProcessStatus::Running,
             mappings: ExecutableMappings(mappings),
             last_used: Instant::now(),
@@ -1556,14 +1563,14 @@ mod tests {
         assert_eq!(profiler.native_unwind_state.executable_count(), 0);
 
         // Add our own process.
-        profiler.event_new_proc(std::process::id() as i32);
+        profiler.event_new_proc(std::process::id() as i32, "test-proc".into());
         let self_exec_mappings_count = maps(&profiler).exec_mappings.keys().count();
         let self_outer_map_count = maps(&profiler).outer_map.keys().count();
         let self_executable_to_page_count = maps(&profiler).executable_to_page.keys().count();
         let self_known_executables_count = profiler.native_unwind_state.executable_count();
 
         // Add init process.
-        profiler.event_new_proc(1_i32);
+        profiler.event_new_proc(1_i32, "test-proc".into());
         let all_exec_mappings_count = maps(&profiler).exec_mappings.keys().count();
         let all_outer_map_count = maps(&profiler).outer_map.keys().count();
         let all_executable_to_page_count = maps(&profiler).executable_to_page.keys().count();


### PR DESCRIPTION
Read process name in BPF
Before this commit, the process name and thread name were read in
userspace, in a best-effort basis. This is problematic as the process
name tends to be one of the most useful aggregation keys but it's not
always possible to read it off procfs due to the process exiting before
we get to read it.

Additionally, reading it from procfs is more expensive as in BPF is a
memory read (after a few pointer dereferences) and kernel locks are
grabbed etc.

As of now, the thread name is still read off procfs, so we might fail to
obtain it. In the future this might be revisited, and thread names might
also be collected from BPF.

Test Plan
=========

CI + manual tests (pprof and flamegraph generation)

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>