### PR TITLE
Bump max allowed profiling frequency

### DIFF
--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -442,7 +442,7 @@ mod tests {
         "20",
         "Sample frequency 20 is not prime - use 19 (before) or 23 (after) instead"
     )]
-    #[case::non_prime_out_of_range1010("1010", "sample frequency not in allowed range")]
+    #[case::non_prime_out_of_range1010("20000", "sample frequency not in allowed range")]
     #[trace]
     fn sample_freq_successes(#[case] desired_freq: String, #[case] expected_msg: String) {
         let execname = env!("CARGO_PKG_NAME");

--- a/src/cli/validators.rs
+++ b/src/cli/validators.rs
@@ -3,7 +3,7 @@ use primal::is_prime;
 use std::ops::RangeInclusive;
 use std::time::Duration;
 
-const SAMPLE_FREQ_RANGE: RangeInclusive<u64> = 1..=1009;
+const SAMPLE_FREQ_RANGE: RangeInclusive<u64> = 1..=10007;
 
 pub(crate) fn parse_duration(arg: &str) -> Result<Duration, std::num::ParseIntError> {
     let seconds = arg.parse()?;


### PR DESCRIPTION
To reach closer parity with perf for CPU profiling, since it defaults to 5K Hz iirc.

Test Plan
=========

CI