### PR TITLE
Add Firefox Profiler format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 flame.svg
 profile.pb
+firefox-profiler.json
 **/bpf/*_skel.rs
 .vmtest.log
 /result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,6 +765,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +1018,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxprof-processed-profile"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
+dependencies = [
+ "bitflags",
+ "debugid",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,6 +1198,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,6 +1216,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1568,6 +1650,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "axum",
  "base64",
  "bindgen",
  "blazesym",
@@ -1577,6 +1660,7 @@ dependencies = [
  "ctrlc",
  "flamelens",
  "flate2",
+ "fxprof-processed-profile",
  "gimli 0.33.1",
  "glob",
  "inferno",
@@ -1604,10 +1688,14 @@ dependencies = [
  "ring",
  "rstest",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
 ]
 
@@ -1785,6 +1873,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +1914,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -2864,6 +2964,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3162,7 +3285,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3218,6 +3353,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3256,6 +3392,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3390,6 +3527,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3408,6 +3551,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,12 @@ parking_lot = { version = "0.12.5", features = ["deadlock_detection"] }
 ring = { workspace = true }
 flamelens = { version = "0.4.0", default-features = false }
 lru = { workspace = true }
+fxprof-processed-profile = "0.8.1"
+serde_json = "1.0.150"
+axum = "0.8.9"
+tokio =  { version = "1.52.3", features = ["rt-multi-thread"] }
+urlencoding = "2.1.3"
+tower-http = { version = "0.6.11", features = ["cors"] }
 
 [dev-dependencies]
 assert_cmd = { version = "2.2.0" }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -42,6 +42,7 @@ pub(crate) enum ProfileSender {
     LocalDisk,
     Remote,
     Pyroscope,
+    Firefox,
 }
 
 #[derive(PartialEq, clap::ValueEnum, Debug, Clone, Default)]
@@ -64,6 +65,7 @@ pub(crate) enum Commands {
     ObjectInfo { path: String },
     ShowUnwind { path: String },
     SystemInfo,
+    Server,
 }
 
 #[derive(Parser, Debug)]

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -5,6 +5,7 @@ use std::io::IsTerminal;
 use std::io::Write;
 use std::panic;
 use std::path::PathBuf;
+use std::process::Command;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -14,11 +15,13 @@ use clap::Parser;
 use crossbeam_channel::bounded;
 use crossbeam_channel::tick;
 use inferno::flamegraph;
+use lightswitch::collector::FirefoxProfilerCollector;
 use lightswitch::collector::{
     AggregatorCollector, Collector, LiveCollector, NullCollector, PyroscopeCollector,
     StreamingCollector,
 };
 use lightswitch::debug_info::DebugInfoManager;
+use lightswitch::profile::symbolize_profile;
 use nix::unistd::Uid;
 use tracing::{debug, error, info, Level};
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -33,9 +36,9 @@ use lightswitch::debug_info::{
     DebugInfoBackendFilesystem, DebugInfoBackendNull, DebugInfoBackendRemote,
 };
 use lightswitch::kernel::kernel_build_id;
-use lightswitch::profile::symbolize_profile;
 use lightswitch::profile::{fold_profile, to_pprof};
 use lightswitch::profiler::{Profiler, ProfilerConfig};
+use lightswitch::server::start_server;
 use lightswitch::unwind_info::compact_unwind_info;
 use lightswitch::unwind_info::CompactUnwindInfoBuilder;
 use lightswitch_object::kernel::kaslr_offset;
@@ -131,6 +134,31 @@ fn main() -> Result<(), Box<dyn Error>> {
                 println!("- kernel ASLR offset: 0x{aslr_offset:x}");
             }
 
+            return Ok(());
+        }
+        Some(Commands::Server) => {
+            // If root, change user to the one that invoked `sudo` as we want to
+            // open the browser with that user.
+            if nix::unistd::geteuid().is_root() {
+                let target_uid = std::env::var("SUDO_UID")
+                    .expect("SUDO_UID not set")
+                    .parse::<u32>()
+                    .expect("SUDO_UID could not be parsed");
+
+                nix::unistd::setuid(Uid::from_raw(target_uid)).unwrap();
+            }
+
+            let cmd = Command::new("xdg-open")
+                .arg("http://localhost:3000")
+                .output()
+                .unwrap();
+            if !cmd.status.success() {
+                println!("`xdg-open` failed with `{:?}`", cmd);
+            }
+
+            let port = 3000;
+            println!("Listening on http://localhost:{port}");
+            start_server(port);
             return Ok(());
         }
     }
@@ -293,9 +321,14 @@ fn main() -> Result<(), Box<dyn Error>> {
                 args.sample_freq,
                 metadata_provider.clone(),
             )),
+            ProfileSender::Firefox => Box::new(FirefoxProfilerCollector::new(
+                "firefox-profiler.json",
+                args.sample_freq,
+                metadata_provider.clone(),
+            )),
         }));
 
-    let mut p: Profiler = Profiler::new(
+    let mut p = Profiler::new(
         profiler_config,
         stop_signal_receive,
         metadata_provider.clone(),
@@ -306,13 +339,17 @@ fn main() -> Result<(), Box<dyn Error>> {
     let collector = collector.lock().unwrap();
     let (mut profile, procs, objs) = collector.finish();
 
-    // If we need to send the profile to the backend there's nothing else to do.
+    // The senders below send the profiles directly.
     match args.sender {
-        ProfileSender::Remote | ProfileSender::Pyroscope | ProfileSender::None => {
+        ProfileSender::Remote
+        | ProfileSender::Pyroscope
+        | ProfileSender::Firefox
+        | ProfileSender::None => {
             return Ok(());
         }
         _ => {}
     }
+
     // Otherwise let's symbolize the profile and write it to disk.
     if args.symbolizer == Symbolizer::Local {
         info!("Symbolizing profile...");
@@ -433,7 +470,7 @@ mod tests {
         cmd.arg("--help");
         cmd.assert().success();
         let actual = String::from_utf8(cmd.unwrap().stdout).unwrap();
-        insta::assert_yaml_snapshot!(actual, @r#""Usage: lightswitch [OPTIONS] [COMMAND]\n\nCommands:\n  object-info  \n  show-unwind  \n  system-info  \n  help         Print this message or the help of the given subcommand(s)\n\nOptions:\n      --pids <PIDS>\n          Specific PIDs to profile\n\n  -D, --duration <DURATION>\n          How long this agent will run in seconds\n          \n          [default: 18446744073709551615]\n\n      --libbpf-debug\n          Enable libbpf logs. This includes the BPF verifier output\n\n      --bpf-logging\n          Enable BPF programs logging\n\n      --btf-custom-path <BTF_CUSTOM_PATH>\n          Alternative BTF file\n\n      --logging <LOGGING>\n          Set lightswitch's logging level\n          \n          [default: info]\n          [possible values: trace, debug, info, warn, error]\n\n      --sample-freq <SAMPLE_FREQ_IN_HZ>\n          Per-CPU Sampling Frequency in Hz\n          \n          [default: 19]\n\n      --profile-format <PROFILE_FORMAT>\n          Output file for Flame Graph in SVG format\n          \n          [default: flame-graph]\n          [possible values: none, flame-graph, pprof]\n\n      --flamegraph-aggregation <FLAMEGRAPH_AGGREGATION>\n          What information to show in the flamegraph. Won't do anything for other profile formats\n          \n          [default: function]\n          [possible values: function, all]\n\n      --profile-path <PROFILE_PATH>\n          Path for the generated profile\n\n      --profile-name <PROFILE_NAME>\n          Name for the generated profile\n\n      --sender <SENDER>\n          Where to write the profile\n\n          Possible values:\n          - none:       Discard the profile. Used for kernel tests\n          - local-disk\n          - remote\n          - pyroscope\n          \n          [default: local-disk]\n\n      --server-url <SERVER_URL>\n          \n\n      --token <TOKEN>\n          \n\n      --pyroscope-app-name <PYROSCOPE_APP_NAME>\n          Application name for Pyroscope\n          \n          [default: lightswitch]\n\n      --pyroscope-tenant-id <PYROSCOPE_TENANT_ID>\n          Tenant ID for multi-tenant Pyroscope (sets `X-Scope-OrgID` header)\n\n      --perf-buffer-bytes <PERF_BUFFER_BYTES>\n          Size of each profiler perf buffer, in bytes (must be a power of 2)\n          \n          [default: 524288]\n\n      --mapsize-info\n          Print eBPF map sizes after creation\n\n      --mapsize-rate-limits <MAPSIZE_RATE_LIMITS>\n          max number of rate limit entries\n          \n          [default: 5000]\n\n      --exclude-self\n          Do not profile the profiler (myself)\n\n      --symbolizer <SYMBOLIZER>\n          [default: local]\n          [possible values: local, none]\n\n      --debug-info-backend <DEBUG_INFO_BACKEND>\n          [default: none]\n          [possible values: none, copy, remote]\n\n      --max-native-unwind-info-size-mb <MAX_NATIVE_UNWIND_INFO_SIZE_MB>\n          approximate max size in megabytes used for the BPF maps that hold unwind information\n          \n          [default: 2147483647]\n\n      --enable-deadlock-detector\n          enable parking_lot's deadlock detector\n\n      --cache-dir-base <CACHE_DIR_BASE>\n          [default: /tmp]\n\n      --killswitch-path-override <KILLSWITCH_PATH_OVERRIDE>\n          Override the default path to the killswitch file (/tmp/lightswitch/killswitch) which prevents the profiler from starting\n\n      --unsafe-start\n          Force the profiler to start even if the system killswitch is enabled\n\n      --force-perf-buffer\n          force perf buffers even if ring buffers can be used\n\n      --no-prealloc-bpf-hash-maps\n          Do not preallocate BPF hash maps\n\n      --preload-thread-metadata\n          Read metadata for all threads when a new process is detected. This might be slow in older kernels.\n\n      --live\n          Launch live flamegraph TUI\n\n  -h, --help\n          Print help (see a summary with '-h')\n""#);
+        insta::assert_yaml_snapshot!(actual, @r#""Usage: lightswitch [OPTIONS] [COMMAND]\n\nCommands:\n  object-info  \n  show-unwind  \n  system-info  \n  server       \n  help         Print this message or the help of the given subcommand(s)\n\nOptions:\n      --pids <PIDS>\n          Specific PIDs to profile\n\n  -D, --duration <DURATION>\n          How long this agent will run in seconds\n          \n          [default: 18446744073709551615]\n\n      --libbpf-debug\n          Enable libbpf logs. This includes the BPF verifier output\n\n      --bpf-logging\n          Enable BPF programs logging\n\n      --btf-custom-path <BTF_CUSTOM_PATH>\n          Alternative BTF file\n\n      --logging <LOGGING>\n          Set lightswitch's logging level\n          \n          [default: info]\n          [possible values: trace, debug, info, warn, error]\n\n      --sample-freq <SAMPLE_FREQ_IN_HZ>\n          Per-CPU Sampling Frequency in Hz\n          \n          [default: 19]\n\n      --profile-format <PROFILE_FORMAT>\n          Output file for Flame Graph in SVG format\n          \n          [default: flame-graph]\n          [possible values: none, flame-graph, pprof]\n\n      --flamegraph-aggregation <FLAMEGRAPH_AGGREGATION>\n          What information to show in the flamegraph. Won't do anything for other profile formats\n          \n          [default: function]\n          [possible values: function, all]\n\n      --profile-path <PROFILE_PATH>\n          Path for the generated profile\n\n      --profile-name <PROFILE_NAME>\n          Name for the generated profile\n\n      --sender <SENDER>\n          Where to write the profile\n\n          Possible values:\n          - none:       Discard the profile. Used for kernel tests\n          - local-disk\n          - remote\n          - pyroscope\n          - firefox\n          \n          [default: local-disk]\n\n      --server-url <SERVER_URL>\n          \n\n      --token <TOKEN>\n          \n\n      --pyroscope-app-name <PYROSCOPE_APP_NAME>\n          Application name for Pyroscope\n          \n          [default: lightswitch]\n\n      --pyroscope-tenant-id <PYROSCOPE_TENANT_ID>\n          Tenant ID for multi-tenant Pyroscope (sets `X-Scope-OrgID` header)\n\n      --perf-buffer-bytes <PERF_BUFFER_BYTES>\n          Size of each profiler perf buffer, in bytes (must be a power of 2)\n          \n          [default: 524288]\n\n      --mapsize-info\n          Print eBPF map sizes after creation\n\n      --mapsize-rate-limits <MAPSIZE_RATE_LIMITS>\n          max number of rate limit entries\n          \n          [default: 5000]\n\n      --exclude-self\n          Do not profile the profiler (myself)\n\n      --symbolizer <SYMBOLIZER>\n          [default: local]\n          [possible values: local, none]\n\n      --debug-info-backend <DEBUG_INFO_BACKEND>\n          [default: none]\n          [possible values: none, copy, remote]\n\n      --max-native-unwind-info-size-mb <MAX_NATIVE_UNWIND_INFO_SIZE_MB>\n          approximate max size in megabytes used for the BPF maps that hold unwind information\n          \n          [default: 2147483647]\n\n      --enable-deadlock-detector\n          enable parking_lot's deadlock detector\n\n      --cache-dir-base <CACHE_DIR_BASE>\n          [default: /tmp]\n\n      --killswitch-path-override <KILLSWITCH_PATH_OVERRIDE>\n          Override the default path to the killswitch file (/tmp/lightswitch/killswitch) which prevents the profiler from starting\n\n      --unsafe-start\n          Force the profiler to start even if the system killswitch is enabled\n\n      --force-perf-buffer\n          force perf buffers even if ring buffers can be used\n\n      --no-prealloc-bpf-hash-maps\n          Do not preallocate BPF hash maps\n\n      --preload-thread-metadata\n          Read metadata for all threads when a new process is detected. This might be slow in older kernels.\n\n      --live\n          Launch live flamegraph TUI\n\n  -h, --help\n          Print help (see a summary with '-h')\n""#);
     }
 
     #[rstest]

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -4,28 +4,33 @@ use flate2::Compression;
 use prost::Message;
 use serde::Serialize;
 use std::collections::HashMap;
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tracing::{debug, span, Level};
+use tracing::{debug, span, warn, Level};
 use uuid::Uuid;
 
+use lightswitch_metadata::{
+    metadata_provider::ThreadSafeGlobalMetadataProvider,
+    types::{MetadataLabelValue, TaskKey},
+};
+use lightswitch_object::ExecutableId;
+use std::fs::File;
+
+use crate::aggregator::Aggregator;
 use crate::process::ObjectFileInfo;
 use crate::process::ProcessInfo;
-use crate::profile::raw_to_processed;
-use crate::profile::AggregatedProfile;
-use crate::profile::AggregatedSample;
-use crate::profile::RawAggregatedProfile;
-use crate::profile::{fold_profile, symbolize_profile, to_pprof};
-use lightswitch_object::ExecutableId;
-
-use lightswitch_metadata::metadata_provider::ThreadSafeGlobalMetadataProvider;
+use crate::profile::{
+    fold_profile, symbolize_profile, to_pprof, AggregatedSample, SymbolizedFrame,
+};
+use crate::profile::{raw_to_processed, RawSample};
+use crate::profile::{AggregatedProfile, RawAggregatedSample};
 
 pub trait Collector {
     fn collect(
         &mut self,
-        profile: RawAggregatedProfile,
+        profile: Vec<RawSample>,
         procs: &HashMap<i32, ProcessInfo>,
         objs: &HashMap<ExecutableId, ObjectFileInfo>,
     );
@@ -56,7 +61,7 @@ impl NullCollector {
 impl Collector for NullCollector {
     fn collect(
         &mut self,
-        _profile: RawAggregatedProfile,
+        _profile: Vec<RawSample>,
         _procs: &HashMap<i32, ProcessInfo>,
         _objs: &HashMap<ExecutableId, ObjectFileInfo>,
     ) {
@@ -117,13 +122,13 @@ impl StreamingCollector {
 impl Collector for StreamingCollector {
     fn collect(
         &mut self,
-        profile: RawAggregatedProfile,
+        profile: Vec<RawSample>,
         procs: &HashMap<i32, ProcessInfo>,
         objs: &HashMap<ExecutableId, ObjectFileInfo>,
     ) {
         let _span = span!(Level::DEBUG, "StreamingCollector.collect").entered();
 
-        let mut profile = raw_to_processed(&profile, procs, objs);
+        let mut profile = raw_to_processed(&Aggregator::default().aggregate(profile), procs, objs);
         if self.local_symbolizer {
             profile = symbolize_profile(&profile, procs, objs);
         }
@@ -244,13 +249,13 @@ struct PyroscopeSample {
 impl Collector for PyroscopeCollector {
     fn collect(
         &mut self,
-        profile: RawAggregatedProfile,
+        profile: Vec<RawSample>,
         procs: &HashMap<i32, ProcessInfo>,
         objs: &HashMap<ExecutableId, ObjectFileInfo>,
     ) {
         let _span = span!(Level::DEBUG, "PyroscopeCollector.collect").entered();
 
-        let mut profile = raw_to_processed(&profile, procs, objs);
+        let mut profile = raw_to_processed(&Aggregator::default().aggregate(profile), procs, objs);
         if self.local_symbolizer {
             profile = symbolize_profile(&profile, procs, objs);
         }
@@ -339,12 +344,15 @@ impl AggregatorCollector {
 impl Collector for AggregatorCollector {
     fn collect(
         &mut self,
-        raw_profile: RawAggregatedProfile,
+        raw_profile: Vec<RawSample>,
         procs: &HashMap<i32, ProcessInfo>,
         objs: &HashMap<ExecutableId, ObjectFileInfo>,
     ) {
-        self.profiles
-            .push(raw_to_processed(&raw_profile, procs, objs));
+        self.profiles.push(raw_to_processed(
+            &Aggregator::default().aggregate(raw_profile),
+            procs,
+            objs,
+        ));
 
         for (k, v) in procs {
             self.procs.insert(*k, v.clone());
@@ -411,13 +419,13 @@ impl LiveCollector {
 impl Collector for LiveCollector {
     fn collect(
         &mut self,
-        raw_profile: RawAggregatedProfile,
+        raw_profile: Vec<RawSample>,
         procs: &HashMap<i32, ProcessInfo>,
         objs: &HashMap<ExecutableId, ObjectFileInfo>,
     ) {
         let _span = span!(Level::DEBUG, "LiveCollector.collect").entered();
 
-        let profile = raw_to_processed(&raw_profile, procs, objs);
+        let profile = raw_to_processed(&Aggregator::default().aggregate(raw_profile), procs, objs);
         let profile = symbolize_profile(&profile, procs, objs);
         let folded = fold_profile(procs, profile, true);
 
@@ -433,6 +441,190 @@ impl Collector for LiveCollector {
         &HashMap<i32, ProcessInfo>,
         &HashMap<ExecutableId, ObjectFileInfo>,
     ) {
+        (AggregatedProfile::new(), &self.procs, &self.objs)
+    }
+}
+
+pub struct FirefoxProfilerCollector {
+    profile_name: String,
+    sample_freq: u64,
+    samples: Vec<AggregatedSample>,
+    timestamps: Vec<u64>,
+    meta: ThreadSafeGlobalMetadataProvider,
+    procs: HashMap<i32, ProcessInfo>,
+    objs: HashMap<ExecutableId, ObjectFileInfo>,
+    pid_to_comm: HashMap<i32, String>,
+}
+
+impl FirefoxProfilerCollector {
+    pub fn new(
+        profile_name: &str,
+        sample_freq: u64,
+        meta: ThreadSafeGlobalMetadataProvider,
+    ) -> Self {
+        FirefoxProfilerCollector {
+            profile_name: profile_name.to_string(),
+            sample_freq,
+            samples: vec![],
+            timestamps: vec![],
+            meta,
+            procs: HashMap::new(),
+            objs: HashMap::new(),
+            pid_to_comm: HashMap::new(),
+        }
+    }
+}
+
+impl Collector for FirefoxProfilerCollector {
+    fn collect(
+        &mut self,
+        samples: Vec<RawSample>,
+        procs: &HashMap<i32, ProcessInfo>,
+        objs: &HashMap<ExecutableId, ObjectFileInfo>,
+    ) {
+        // Add timestamps
+        for sample in &samples {
+            self.timestamps.push(sample.collected_at);
+        }
+
+        // fake agg + normalize
+        let profile = samples
+            .iter()
+            .map(|e| RawAggregatedSample {
+                sample: e.clone(),
+                count: 1,
+            })
+            .collect::<Vec<_>>();
+
+        for (pid, proc_info) in procs {
+            self.pid_to_comm
+                .entry(*pid)
+                .or_insert(proc_info.comm.clone());
+        }
+
+        let profile = raw_to_processed(&profile, procs, objs);
+        let mut profile = symbolize_profile(&profile, procs, objs);
+        self.samples.append(&mut profile);
+    }
+
+    fn finish(
+        &self,
+    ) -> (
+        AggregatedProfile,
+        &HashMap<i32, ProcessInfo>,
+        &HashMap<ExecutableId, ObjectFileInfo>,
+    ) {
+        use fxprof_processed_profile::*;
+
+        if self.timestamps.is_empty() {
+            warn!("got no samples");
+            return (AggregatedProfile::new(), &self.procs, &self.objs);
+        }
+
+        let reference_timestamp = *self.timestamps.first().expect("check above");
+        let mut ff_processes: HashMap<i32, ProcessHandle> = HashMap::new();
+        let mut ff_threads: HashMap<i32, ThreadHandle> = HashMap::new();
+        let mut ff_profile = Profile::new(
+            "lightswitch",
+            ReferenceTimestamp::from_duration_since_unix_epoch(Duration::from_nanos(
+                reference_timestamp,
+            )),
+            SamplingInterval::from_hz(self.sample_freq as f32),
+        );
+        let userspace_category = ff_profile.add_category("userspace", CategoryColor::Blue);
+        let kernel_category = ff_profile.add_category("kernel", CategoryColor::Gray);
+
+        for (timestamp, sample) in self.timestamps.iter().zip(&self.samples) {
+            let meta = self
+                .meta
+                .lock()
+                .expect("acquire metadata lock")
+                .get_metadata(TaskKey {
+                    pid: sample.pid,
+                    tid: sample.tid,
+                });
+
+            let process_name = &self
+                .pid_to_comm
+                .get(&sample.pid)
+                .expect("process to have a name");
+            let thread_name = match &meta.iter().find(|e| e.key == "thread.name").unwrap().value {
+                MetadataLabelValue::String(a) => a,
+                MetadataLabelValue::Number(_, _) => todo!(),
+            };
+
+            let ff_process = match ff_processes.entry(sample.pid) {
+                std::collections::hash_map::Entry::Occupied(occupied_entry) => {
+                    *occupied_entry.get()
+                }
+                std::collections::hash_map::Entry::Vacant(vacant_entry) => {
+                    let p = ff_profile.add_process(
+                        process_name,
+                        sample.pid as u32,
+                        Timestamp::from_nanos_since_reference(timestamp - reference_timestamp),
+                    );
+                    vacant_entry.insert(p);
+                    p
+                }
+            };
+
+            let ff_thread = match ff_threads.entry(sample.tid) {
+                std::collections::hash_map::Entry::Occupied(occupied_entry) => {
+                    *occupied_entry.get()
+                }
+                std::collections::hash_map::Entry::Vacant(vacant_entry) => {
+                    let t = ff_profile.add_thread(
+                        ff_process,
+                        sample.tid as u32,
+                        Timestamp::from_nanos_since_reference(timestamp - reference_timestamp),
+                        sample.pid == sample.tid,
+                    );
+                    ff_profile.set_thread_name(t, thread_name);
+                    vacant_entry.insert(t);
+                    t
+                }
+            };
+
+            let frames = sample
+                .ustack
+                .iter()
+                .rev()
+                .map(|e| (e, userspace_category))
+                .chain(sample.kstack.iter().rev().map(|e| (e, kernel_category)))
+                .map(|(e, cat)| FrameInfo {
+                    frame: Frame::Label(
+                        ff_profile.intern_string(
+                            &e.symbolization_result
+                                .as_ref()
+                                .unwrap()
+                                .as_ref()
+                                .unwrap_or(&SymbolizedFrame {
+                                    name: "not found".to_string(),
+                                    inlined: false,
+                                    filename: None,
+                                    line: None,
+                                })
+                                .name,
+                        ),
+                    ),
+                    category_pair: cat.into(),
+                    flags: FrameFlags::empty(),
+                })
+                .collect::<Vec<_>>();
+
+            let stack = ff_profile.intern_stack_frames(ff_thread, frames.into_iter());
+            ff_profile.add_sample(
+                ff_thread,
+                Timestamp::from_nanos_since_reference(timestamp - reference_timestamp),
+                stack,
+                CpuDelta::ZERO,
+                1,
+            );
+        }
+
+        let file = File::create(&self.profile_name).unwrap();
+        serde_json::to_writer(&mut BufWriter::new(file), &ff_profile).unwrap();
+
         (AggregatedProfile::new(), &self.procs, &self.objs)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod perf_events;
 pub mod process;
 pub mod profile;
 pub mod profiler;
+pub mod server;
 pub mod unwind_info;
 pub mod usym;
 pub mod util;

--- a/src/profile/sample.rs
+++ b/src/profile/sample.rs
@@ -183,10 +183,6 @@ impl RawAggregatedSample {
             });
         }
 
-        if processed_sample.ustack.is_empty() && processed_sample.kstack.is_empty() {
-            return Err(anyhow!("no user or kernel stack present"));
-        }
-
         Ok(processed_sample)
     }
 }
@@ -234,7 +230,7 @@ impl fmt::Display for AggregatedSample {
             format!("[{}]", res.join(","))
         };
 
-        fmt.debug_struct("SymbolizedAggregatedSample")
+        fmt.debug_struct("AggregatedSample")
             .field("pid", &self.pid)
             .field("tid", &self.tid)
             .field("ustack", &format_symbolized_stack(&self.ustack))
@@ -398,7 +394,7 @@ mod tests {
             kstack: kstack_data.clone(),
             count: 128,
         };
-        insta::assert_yaml_snapshot!(format!("{}", sample), @r#""SymbolizedAggregatedSample { pid: 1234567, tid: 1234568, ustack: \"[  0: ufunc3,  1: ufunc2,  2: ufunc1]\", kstack: \"[  0: kfunc2,  1: kfunc1]\", count: 128 }""#);
+        insta::assert_yaml_snapshot!(format!("{}", sample), @r#""AggregatedSample { pid: 1234567, tid: 1234568, ustack: \"[  0: ufunc3,  1: ufunc2,  2: ufunc1]\", kstack: \"[  0: kfunc2,  1: kfunc1]\", count: 128 }""#);
 
         let ustack_data = vec![];
 
@@ -409,6 +405,6 @@ mod tests {
             kstack: kstack_data.clone(),
             count: 1001,
         };
-        insta::assert_yaml_snapshot!(format!("{}", sample), @r#""SymbolizedAggregatedSample { pid: 98765, tid: 98766, ustack: \"[NONE]\", kstack: \"[  0: kfunc2,  1: kfunc1]\", count: 1001 }""#);
+        insta::assert_yaml_snapshot!(format!("{}", sample), @r#""AggregatedSample { pid: 98765, tid: 98766, ustack: \"[NONE]\", kstack: \"[  0: kfunc2,  1: kfunc1]\", count: 1001 }""#);
     }
 }

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -39,7 +39,6 @@ use itertools::Itertools;
 use procfs;
 use tracing::{debug, error, info, span, warn, Level};
 
-use crate::aggregator::Aggregator;
 use crate::bpf::profiler_bindings::*;
 use crate::bpf::tracers_bindings::*;
 use crate::collector::*;
@@ -88,8 +87,8 @@ pub struct Profiler {
     /// Pids excluded from profiling.
     filter_pids: HashMap<Pid, bool>,
     /// Profile channels.
-    profile_send: Arc<Sender<RawAggregatedProfile>>,
-    profile_receive: Arc<Receiver<RawAggregatedProfile>>,
+    profile_send: Arc<Sender<Vec<RawSample>>>,
+    profile_receive: Arc<Receiver<Vec<RawSample>>>,
     /// A vector of raw samples received from bpf in the current profiling
     /// session
     raw_samples: Vec<RawSample>,
@@ -116,7 +115,6 @@ pub struct Profiler {
     max_native_unwind_info_size_mb: i32,
     unwind_info_manager: UnwindInfoManager,
     use_ring_buffers: bool,
-    aggregator: Aggregator,
     metadata_provider: ThreadSafeGlobalMetadataProvider,
     /// Baseline for calculating raw_sample collection wall clock time
     /// as BPF currently only supports getting the offset since system boot.
@@ -323,7 +321,6 @@ impl Profiler {
             max_native_unwind_info_size_mb: profiler_config.max_native_unwind_info_size_mb,
             unwind_info_manager: UnwindInfoManager::new(&unwind_cache_dir, None),
             use_ring_buffers: profiler_config.use_ring_buffers,
-            aggregator: Aggregator::default(),
             metadata_provider,
             walltime_at_system_boot,
             preload_thread_metadata: profiler_config.preload_thread_metadata,
@@ -345,7 +342,7 @@ impl Profiler {
         }
     }
 
-    pub fn send_profile(&mut self, profile: RawAggregatedProfile) {
+    pub fn send_profile(&mut self, profile: Vec<RawSample>) {
         if let Err(e) = self.profile_send.send(profile) {
             debug!("failed to send profile with: `{:?}`", e);
         }
@@ -686,12 +683,12 @@ impl Profiler {
 
     /// Updates the last time processes and executables were seen. This is used
     /// during evictions.
-    pub fn bump_last_used(&mut self, raw_aggregated_samples: &[RawAggregatedSample]) {
+    pub fn bump_last_used(&mut self, raw_samples: &[RawSample]) {
         let now = Instant::now();
 
-        for aggregated_sample in raw_aggregated_samples {
-            let pid = aggregated_sample.sample.pid;
-            let ustack = &aggregated_sample.sample.ustack;
+        for raw_sample in raw_samples {
+            let pid = raw_sample.pid;
+            let ustack = &raw_sample.ustack;
             {
                 let mut procs = self.procs.write();
                 let proc = procs.get_mut(&pid);
@@ -728,15 +725,13 @@ impl Profiler {
         clear_map(&rate_limits_map);
     }
 
-    pub fn collect_profile(&mut self) -> RawAggregatedProfile {
+    pub fn collect_profile(&mut self) -> Vec<RawSample> {
         debug!("collecting profile");
-        let result = self.aggregator.aggregate(self.raw_samples.clone());
-        self.raw_samples.clear();
-
-        self.bump_last_used(&result);
+        let raw_samples = std::mem::take(&mut self.raw_samples);
+        self.bump_last_used(&raw_samples);
         self.bpf.show_unwinder_stats();
         self.clear_maps();
-        result
+        raw_samples
     }
 
     fn process_is_known(&self, pid: Pid) -> bool {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,53 @@
+use axum::http::HeaderValue;
+use axum::{body::Body, http::Response};
+use axum::{http::header, response::Html, routing::get, Router};
+use reqwest::Method;
+use std::{fs::File, io::Read};
+
+const FIREFOX_PROFILER_URL: &str = "https://profiler.firefox.com";
+
+pub fn start_server(port: u16) {
+    tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(async_start_server(port));
+}
+
+async fn async_start_server(port: u16) {
+    use tower_http::cors::*;
+
+    let cors = CorsLayer::new()
+        .allow_origin(HeaderValue::from_static(FIREFOX_PROFILER_URL))
+        .allow_methods([Method::GET]);
+
+    let app = Router::new()
+        .route(
+            "/",
+            get(async || {
+                Html(format!(
+                    "<a href='{}/from-url/{}'>Open profile in the Firefox Profiler UI</a>",
+                    FIREFOX_PROFILER_URL,
+                    urlencoding::encode("http://localhost:3000/profile.json")
+                ))
+            }),
+        )
+        .route(
+            "/profile.json",
+            get(async || {
+                let mut file = File::open("firefox-profiler.json").unwrap();
+                let mut ff_profile = Vec::new();
+                file.read_to_end(&mut ff_profile).unwrap();
+                let response = str::from_utf8(&ff_profile).unwrap().to_string();
+
+                Response::builder()
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(response))
+                    .unwrap()
+            }),
+        )
+        .layer(cors);
+
+    let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{}", port))
+        .await
+        .unwrap();
+    axum::serve(listener, app).await.unwrap();
+}


### PR DESCRIPTION
Add support for Firefox Profiler
This commit adds support for writing profiles in the format that Firefox
Profiler uses as well as a simple HTTP server `lightswitch server` to
load the profile in the UI with fewer steps.

Test Plan
=========

CI + manual tests

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>