### PR TITLE
tracers: Read pid and tid from the right namespace

### DIFF
--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -114,6 +114,8 @@ const volatile struct lightswitch_config_t lightswitch_config = {
     .verbose_logging = false,
     .use_ring_buffers = false,
     .use_task_pt_regs_helper = false,
+    .use_btf_helpers = false,
+    .userspace_pid_ns_level = -1,
 };
 
 #define LOG(fmt, ...)                             \

--- a/src/bpf/tracers.bpf.c
+++ b/src/bpf/tracers.bpf.c
@@ -8,7 +8,7 @@
 #include <bpf/bpf_core_read.h>
 
 typedef struct {
-    u64 pid_tgid;
+    u32 tid;
 } mmap_data_key_t;
 
 struct {
@@ -45,7 +45,7 @@ struct munmap_entry_args {
 SEC("tracepoint/sched/sched_process_exit")
 int tracer_process_exit(void *ctx) {
     struct task_struct *task = current_task();
-    unsigned int level = BPF_CORE_READ(task, nsproxy, pid_ns_for_children, level);
+    unsigned int level = lightswitch_config.userspace_pid_ns_level;
     int per_process_id = BPF_CORE_READ(task, group_leader, thread_pid, numbers[level].nr);
     int per_thread_id = BPF_CORE_READ(task, thread_pid, numbers[level].nr);
 
@@ -60,7 +60,7 @@ int tracer_process_exit(void *ctx) {
 
     tracer_event_t event = {
         .type = TRACER_EVENT_TYPE_PROCESS_EXIT,
-        .pid = bpf_get_current_pid_tgid() >> 32,
+        .pid = per_process_id,
         .start_address = 0,
     };
 
@@ -83,7 +83,7 @@ SEC("tracepoint/syscalls/sys_enter_munmap")
 int tracer_enter_munmap(struct munmap_entry_args *args) {
     u64 start_address = args->addr;
     struct task_struct *task = current_task();
-    unsigned int level = BPF_CORE_READ(task, nsproxy, pid_ns_for_children, level);
+    unsigned int level = lightswitch_config.userspace_pid_ns_level;
     int per_process_id = BPF_CORE_READ(task, group_leader, thread_pid, numbers[level].nr);
 
     // We might not know about some mappings, but also we definitely don't want to notify
@@ -98,8 +98,9 @@ int tracer_enter_munmap(struct munmap_entry_args *args) {
         return 0;
     }
 
+    int per_thread_id = BPF_CORE_READ(task, thread_pid, numbers[level].nr);
     mmap_data_key_t key = {
-        .pid_tgid = bpf_get_current_pid_tgid(),
+        .tid = per_thread_id,
     };
     bpf_map_update_elem(&tracked_munmap, &key, &start_address, BPF_ANY);
 
@@ -108,8 +109,12 @@ int tracer_enter_munmap(struct munmap_entry_args *args) {
 
 SEC("tracepoint/syscalls/sys_exit_munmap")
 int tracer_exit_munmap(struct syscall_trace_exit *ctx) {
+    struct task_struct *task = current_task();
+    unsigned int level = lightswitch_config.userspace_pid_ns_level;
+    int per_thread_id = BPF_CORE_READ(task, thread_pid, numbers[level].nr);
+
     mmap_data_key_t key = {
-        .pid_tgid = bpf_get_current_pid_tgid(),
+        .tid = per_thread_id,
     };
 
     u64 *start_address = bpf_map_lookup_elem(&tracked_munmap, &key);
@@ -124,9 +129,10 @@ int tracer_exit_munmap(struct syscall_trace_exit *ctx) {
 
     LOG("[debug] sending munmap event");
 
+    int per_process_id = BPF_CORE_READ(task, group_leader, thread_pid, numbers[level].nr);
     tracer_event_t event = {
         .type = TRACER_EVENT_TYPE_MUNMAP,
-        .pid = bpf_get_current_pid_tgid() >> 32,
+        .pid = per_process_id,
         .start_address = *start_address,
     };
 

--- a/src/bpf_objects.rs
+++ b/src/bpf_objects.rs
@@ -2,7 +2,7 @@ use std::{
     collections::hash_map::OccupiedEntry,
     iter,
     mem::{ManuallyDrop, MaybeUninit},
-    os::fd::{AsFd, AsRawFd},
+    os::fd::{AsFd, AsRawFd, BorrowedFd},
 };
 
 use crate::{
@@ -101,34 +101,8 @@ impl Bpf {
             .open(&mut tracers_open_object)
             .expect("open skel");
 
-        open_tracers
-            .maps
-            .exec_mappings
-            .reuse_fd(exec_mappings_fd)
-            .expect("reuse exec_mappings");
-
-        let rodata = open_tracers
-            .maps
-            .rodata_data
-            .as_mut()
-            .expect(".rodata must be present");
-        rodata
-            .lightswitch_config
-            .verbose_logging
-            .write(profiler_config.bpf_logging);
-        rodata
-            .lightswitch_config
-            .use_ring_buffers
-            .write(profiler_config.use_ring_buffers);
-
-        // Disable BTF helpers if a BTF custom path is selected since
-        // it will not load in machines that don't have one. TODO add override?
-        rodata
-            .lightswitch_config
-            .use_btf_helpers
-            .write(profiler_config.btf_custom_path.is_none());
         Self::set_tracers_map_sizes(&mut open_tracers, profiler_config);
-
+        Self::setup_tracers_maps(&mut open_tracers, profiler_config, exec_mappings_fd);
         let tracers = ManuallyDrop::new(open_tracers.load().expect("load skel"));
         // SAFETY: tracers never outlives tracers_open_object
         let tracers = unsafe {
@@ -210,7 +184,42 @@ impl Bpf {
         roundup_page(max_entries_bytes as usize) as u32
     }
 
-    pub fn setup_profiler_maps(open_skel: &mut OpenProfilerSkel, profiler_config: &ProfilerConfig) {
+    fn setup_tracers_maps(
+        open_tracers: &mut OpenTracersSkel,
+        profiler_config: &ProfilerConfig,
+        exec_mappings_fd: BorrowedFd,
+    ) {
+        open_tracers
+            .maps
+            .exec_mappings
+            .reuse_fd(exec_mappings_fd)
+            .expect("reuse exec_mappings");
+
+        let rodata = open_tracers
+            .maps
+            .rodata_data
+            .as_mut()
+            .expect(".rodata must be present");
+        rodata
+            .lightswitch_config
+            .verbose_logging
+            .write(profiler_config.bpf_logging);
+        rodata
+            .lightswitch_config
+            .use_ring_buffers
+            .write(profiler_config.use_ring_buffers);
+
+        rodata.lightswitch_config.userspace_pid_ns_level = profiler_config.userspace_pid_ns_level;
+
+        // Disable BTF helpers if a BTF custom path is selected since
+        // it will not load in machines that don't have one. TODO add override?
+        rodata
+            .lightswitch_config
+            .use_btf_helpers
+            .write(profiler_config.btf_custom_path.is_none());
+    }
+
+    fn setup_profiler_maps(open_skel: &mut OpenProfilerSkel, profiler_config: &ProfilerConfig) {
         open_skel
             .maps
             .rate_limits


### PR DESCRIPTION
This fixes reading the process and thread id from the tracers so it works well in containerised workloads.

Note that there's a case we don't cover. If lightswitch itself runs in a non-root pid namespace, we might attempt an invalid offset for tasks that run in parent namespaces.

Test Plan
=========

CI