### PR TITLE
Increase maximum stack size to 200 frames

### DIFF
--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -3,9 +3,9 @@
 // Number of frames to walk per tail call iteration.
 #define MAX_STACK_DEPTH_PER_PROGRAM 7
 // Number of BPF tail calls that will be attempted.
-#define MAX_TAIL_CALLS 19
+#define MAX_TAIL_CALLS 30
 // Maximum number of frames.
-#define MAX_STACK_DEPTH 127
+#define MAX_STACK_DEPTH 200
 _Static_assert(MAX_TAIL_CALLS *MAX_STACK_DEPTH_PER_PROGRAM >= MAX_STACK_DEPTH,
                "enough iterations to traverse the whole stack");
 // Number of unique stacks.

--- a/src/profile/sample.rs
+++ b/src/profile/sample.rs
@@ -44,7 +44,7 @@ impl RawSample {
         if sample_len < 24 {
             return Err(RawSampleParsingError::BeforeStackTooSmall);
         }
-        if sample_len > 24 + 127 * 2 * 8 {
+        if sample_len > 24 + 200 * 2 * 8 {
             return Err(RawSampleParsingError::SampleTooLarge);
         }
 
@@ -267,7 +267,7 @@ mod tests {
             stack: native_stack_t {
                 ulen: 2,
                 klen: 1,
-                addresses: [0; 254],
+                addresses: [0; 400],
             },
         };
         assert_eq!(
@@ -285,7 +285,7 @@ mod tests {
             stack: native_stack_t {
                 ulen: 2,
                 klen: 1,
-                addresses: [0; 254],
+                addresses: [0; 400],
             },
         };
         let bytes = unsafe { plain::as_bytes(&c_sample) };
@@ -307,7 +307,7 @@ mod tests {
             stack: native_stack_t {
                 ulen: 2,
                 klen: 1,
-                addresses: [0; 254],
+                addresses: [0; 400],
             },
         };
 


### PR DESCRIPTION
Many applications I use on the daily, such as Zed have very deep stacks. This is useful to have as perf has a 127 stack limit which I don't think increased.

Test Plan
=========

CI