### PR TITLE
Fix local kernel symbolization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Unreleased
 - object: Stop treating v8 as a special case
 - Increase maximum stack size to 200 frames
 - Add opt-in support for fetching Kubernetes metadata
+- Sort kernel symbols obtained from `/proc/kallsyms` and fix kernel module start address parsing
 
 v0.4.0
 ------

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -80,10 +80,13 @@ fn _get_module_build_id(module_name: &str) -> Result<BuildId, anyhow::Error> {
 /// Finds the virtual address at which a given kernel module is loaded.
 fn _module_start_address(module_name: &str) -> Result<u64, anyhow::Error> {
     let mut file = File::open(format!("/sys/module/{module_name}/sections/.text"))?;
-    let mut buffer = [0; 8];
-    file.read_exact(&mut buffer)?;
+    let mut buffer = Vec::with_capacity(16 + 2 + 1); // characters for a hex address in ascii + `0x` + newline
+    file.read_to_end(&mut buffer)?;
 
-    Ok(u64::from_ne_bytes(buffer))
+    Ok(u64::from_str_radix(
+        std::str::from_utf8(buffer[2..].trim_ascii_end())?,
+        16,
+    )?)
 }
 
 /// Read and parse the build id of the running kernel image.

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -3,7 +3,7 @@ use std::io::{BufRead, BufReader, Read};
 
 pub const KALLSYM_PATH: &str = "/proc/kallsyms";
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Ksym {
     pub start_addr: u64,
     pub symbol_name: String,

--- a/src/profile/convert.rs
+++ b/src/profile/convert.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use lightswitch_metadata::metadata_provider::ThreadSafeGlobalMetadataProvider;
 use lightswitch_metadata::task_metadata::PROCESS_NAME_KEY;
 use lightswitch_metadata::taskname::ThreadInfo;
@@ -313,7 +314,10 @@ pub fn symbolize_profile(
     let mut r = AggregatedProfile::new();
 
     let addresses_per_sample = fetch_symbols_for_profile(profile, procs, objs);
-    let ksyms = KsymIter::from_kallsyms().collect::<Vec<_>>();
+    // The kernel symbolizer expects the symbols from kall syms to be sorted
+    let ksyms = KsymIter::from_kallsyms()
+        .sorted_by(|a, b| a.start_addr.cmp(&b.start_addr))
+        .collect::<Vec<_>>();
 
     for sample in profile {
         let symbolized_sample = AggregatedSample {


### PR DESCRIPTION
- sort the symbols by address, since we'll binary search over them
- correctly parse the start address of kernel modules

Test Plan
=========

```
cryptsetup benchmark --cipher aes-xts-plain64 --key-size 256
```

<img width="703" height="366" alt="image" src="https://github.com/user-attachments/assets/ee86d947-7a2d-45a4-9a04-8ed350e7d9a1" />
