### PR TITLE
Unify env variable to enable libbpf logs in tests

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -153,7 +153,7 @@ impl Default for ProfilerConfig {
     fn default() -> Self {
         Self {
             cache_dir_base: temp_dir(),
-            libbpf_debug: std::env::var("LIBBPF_DEBUG").is_ok(),
+            libbpf_debug: false,
             bpf_logging: false,
             duration: Duration::MAX,
             sample_freq: 19,

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -153,7 +153,7 @@ impl Default for ProfilerConfig {
     fn default() -> Self {
         Self {
             cache_dir_base: temp_dir(),
-            libbpf_debug: false,
+            libbpf_debug: std::env::var("LIBBPF_DEBUG").is_ok(),
             bpf_logging: false,
             duration: Duration::MAX,
             sample_freq: 19,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -146,7 +146,7 @@ fn stack_strings_for_pid(symbolized_profile: &AggregatedProfile, expected_pid: i
 
 #[test]
 fn test_integration() {
-    let bpf_test_debug = std::env::var("TEST_DEBUG_BPF").is_ok();
+    let bpf_test_debug = std::env::var("TEST_LIBBPF_DEBUG").is_ok();
     let system_info = SystemInfo::new(None).expect("failed to detect system info");
 
     build_test_binary("integration-tests-progs");
@@ -257,7 +257,7 @@ fn test_integration() {
 
 #[test]
 fn test_integration_ocaml_native_defaults() {
-    let bpf_test_debug = std::env::var("TEST_DEBUG_BPF").is_ok();
+    let bpf_test_debug = std::env::var("TEST_LIBBPF_DEBUG").is_ok();
     let system_info = SystemInfo::new(None).expect("failed to detect system info");
 
     build_test_binary("integration-tests-progs");
@@ -298,7 +298,7 @@ fn test_integration_ocaml_native_defaults() {
 
 #[test]
 fn test_use_pt_regs_helper() {
-    let bpf_test_debug = std::env::var("TEST_DEBUG_BPF").is_ok();
+    let bpf_test_debug = std::env::var("TEST_LIBBPF_DEBUG").is_ok();
 
     let collector = Arc::new(Mutex::new(
         Box::new(NullCollector::new()) as Box<dyn Collector + Send>
@@ -320,7 +320,7 @@ fn test_use_pt_regs_helper() {
 
 #[test]
 fn test_do_not_use_pt_regs_helper() {
-    let bpf_test_debug = std::env::var("TEST_DEBUG_BPF").is_ok();
+    let bpf_test_debug = std::env::var("TEST_LIBBPF_DEBUG").is_ok();
 
     let collector = Arc::new(Mutex::new(
         Box::new(NullCollector::new()) as Box<dyn Collector + Send>


### PR DESCRIPTION
- This allows getting BPF verifier debug output when such tests fail