### PR TITLE
Fix BPF tests failing because use_task_pt_regs_helper defaults to true

### DIFF
--- a/src/bpf_objects.rs
+++ b/src/bpf_objects.rs
@@ -671,7 +671,10 @@ mod tests {
 
     #[test]
     fn test_bpf_mappings_creation_and_deletion() {
-        let profiler_config = ProfilerConfig::default();
+        let profiler_config = ProfilerConfig {
+            use_task_pt_regs_helper: false,
+            ..ProfilerConfig::default()
+        };
         let bpf = Bpf::new(&profiler_config);
         let native_unwinder = &bpf.native_unwinder;
 

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -1556,7 +1556,18 @@ mod tests {
             &profiler.bpf.native_unwinder.maps
         }
 
-        let mut profiler = Profiler::default();
+        let (_stop_signal_send, stop_signal_receive) = crossbeam_channel::bounded(1);
+        let metadata_provider = std::sync::Arc::new(std::sync::Mutex::new(
+            lightswitch_metadata::metadata_provider::GlobalMetadataProvider::default(),
+        ));
+        let mut profiler = Profiler::new(
+            ProfilerConfig {
+                use_task_pt_regs_helper: false,
+                ..ProfilerConfig::default()
+            },
+            stop_signal_receive,
+            metadata_provider,
+        );
 
         // All BPF maps must be empty.
         assert_eq!(maps(&profiler).exec_mappings.keys().count(), 0);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -167,6 +167,8 @@ fn test_integration() {
         duration: Duration::from_secs(5),
         sample_freq: 999,
         userspace_pid_ns_level: system_info.available_bpf_features.userspace_pid_ns_level,
+        use_task_pt_regs_helper: system_info.available_bpf_features.has_task_pt_regs_helper
+            && system_info.available_bpf_features.has_get_current_task_btf,
         ..Default::default()
     };
     let (_stop_signal_send, stop_signal_receive) = bounded(1);
@@ -273,6 +275,8 @@ fn test_integration_ocaml_native_defaults() {
         duration: Duration::from_secs(5),
         sample_freq: 999,
         userspace_pid_ns_level: system_info.available_bpf_features.userspace_pid_ns_level,
+        use_task_pt_regs_helper: system_info.available_bpf_features.has_task_pt_regs_helper
+            && system_info.available_bpf_features.has_get_current_task_btf,
         ..Default::default()
     };
     let (_stop_signal_send, stop_signal_receive) = bounded(1);
@@ -299,6 +303,12 @@ fn test_integration_ocaml_native_defaults() {
 #[test]
 fn test_use_pt_regs_helper() {
     let bpf_test_debug = std::env::var("TEST_DEBUG_BPF").is_ok();
+    let system_info = SystemInfo::new(None).expect("failed to detect system info");
+    if !system_info.available_bpf_features.has_task_pt_regs_helper
+        || !system_info.available_bpf_features.has_get_current_task_btf
+    {
+        return;
+    }
 
     let collector = Arc::new(Mutex::new(
         Box::new(NullCollector::new()) as Box<dyn Collector + Send>
@@ -330,7 +340,7 @@ fn test_do_not_use_pt_regs_helper() {
         libbpf_debug: bpf_test_debug,
         bpf_logging: bpf_test_debug,
         duration: Duration::from_millis(100),
-        use_task_pt_regs_helper: true,
+        use_task_pt_regs_helper: false,
         ..Default::default()
     };
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -307,6 +307,7 @@ fn test_use_pt_regs_helper() {
     if !system_info.available_bpf_features.has_task_pt_regs_helper
         || !system_info.available_bpf_features.has_get_current_task_btf
     {
+        eprintln!("Skipping test_use_pt_regs_helper: required BPF features (task_pt_regs helper and/or get_current_task BTF) are not available on this system");
         return;
     }
 


### PR DESCRIPTION
* Fix the tests that fail because use_task_pt_regs_helper defaults to `true`
* Once those pass, subsequent integration tests fail on RHEL 8.10 - fix those