### PR TITLE
build: Compile BPF code with bare clang

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -65,25 +65,14 @@ fn main() {
     let skel = Path::new(PROFILER_SKELETON);
     SkeletonBuilder::new()
         .source(PROFILER_BPF_SOURCE)
-        .clang_args([
-            "-Wextra",
-            "-Wall",
-            "-Werror",
-            "-Wno-unused-command-line-argument",
-        ])
+        .clang_args(["-Wextra", "-Wall", "-Werror"])
         .build_and_generate(skel)
         .expect("run skeleton builder");
 
     let skel = Path::new(TRACERS_SKELETON);
     SkeletonBuilder::new()
         .source(TRACERS_BPF_SOURCE)
-        .clang_args([
-            "-Wextra",
-            "-Wall",
-            "-Werror",
-            "-Wno-unused-command-line-argument",
-            "-Wno-unused-function",
-        ])
+        .clang_args(["-Wextra", "-Wall", "-Werror", "-Wno-unused-function"])
         .build_and_generate(skel)
         .expect("run skeleton builder");
 }

--- a/flake.nix
+++ b/flake.nix
@@ -25,8 +25,18 @@
             configureFlags = attrs.configureFlags ++ [ "--without-zstd" ];
             nativeBuildInputs = attrs.nativeBuildInputs ++ [ pkgs.pkg-config ];
           });
+          # Nix provided `clang` adds a few compilation options that can't be used for BPF.
+          clang' = with pkgs; (
+            pkgs.writeShellScriptBin "clang" ''
+              if [[ "$@" =~ "-target bpf" ]]; then
+                exec ${llvmPackages_19.clang-unwrapped}/bin/clang -I${llvmPackages_19.clang-unwrapped.lib}/lib/clang/19/include "$@"
+              else
+                exec ${llvmPackages_19.clang}/bin/clang "$@"
+              fi
+            ''
+          );
           buildInputs = with pkgs; [
-            llvmPackages_19.clang
+            clang'
             llvmPackages_19.libcxx
             llvmPackages_19.libclang
             llvmPackages_19.lld

--- a/lightswitch-capabilities/build.rs
+++ b/lightswitch-capabilities/build.rs
@@ -17,26 +17,14 @@ fn main() {
     let skel = Path::new(FEATURES_SKELETON);
     SkeletonBuilder::new()
         .source(FEATURES_BPF_SOURCE)
-        .clang_args([
-            "-Wextra",
-            "-Wall",
-            "-Werror",
-            "-Wno-unused-command-line-argument",
-            "-Wno-unused-parameter",
-        ])
+        .clang_args(["-Wextra", "-Wall", "-Werror"])
         .build_and_generate(skel)
         .expect("run skeleton builder");
 
     let noprealloc_skel = Path::new(NOPREALLOC_TEST_SKELETON);
     SkeletonBuilder::new()
         .source(NOPREALLOC_TEST_BPF_SOURCE)
-        .clang_args([
-            "-Wextra",
-            "-Wall",
-            "-Werror",
-            "-Wno-unused-command-line-argument",
-            "-Wno-unused-parameter",
-        ])
+        .clang_args(["-Wextra", "-Wall", "-Werror"])
         .build_and_generate(noprealloc_skel)
         .expect("run noprealloc_test skeleton builder");
 }

--- a/lightswitch-capabilities/src/bpf/features.bpf.c
+++ b/lightswitch-capabilities/src/bpf/features.bpf.c
@@ -17,7 +17,7 @@ bool has_get_current_task_btf = false;
 unsigned int userspace_pid_ns_level = 0;
 
 SEC("tracepoint/sched/sched_switch")
-int detect_bpf_features(void *ctx) {
+int detect_bpf_features() {
     struct task_struct * task = (struct task_struct *)bpf_get_current_task();
 
     // To fetch the "level" of the pid namespace where userspace is running in,

--- a/lightswitch-capabilities/src/bpf/noprealloc_test.bpf.c
+++ b/lightswitch-capabilities/src/bpf/noprealloc_test.bpf.c
@@ -13,7 +13,7 @@ struct {
 } noprealloc_test_map SEC(".maps");
 
 SEC("tracepoint/sched/sched_switch")
-int test_noprealloc(void *ctx) {
+int test_noprealloc() {
     u32 key = 0;
     bpf_map_lookup_elem(&noprealloc_test_map, &key);
     return 0;


### PR DESCRIPTION
Nix's built clang is really a wrapper for clang that adds a bunch of flags, including some to enhance security such as hardening flags, which can't be used in BPF and they are ignored. This also adds a bunch of include paths.

This commit adds a new "clang" binary that by default will use the "wrapped" version with extra flags, but when using the BPF backend, it'll use bare clang with the minimal include paths needed

With this change, `-Wno-unused-command-line-argument` can now be removed. Unrelated to this change, `-Wno-unused-parameter` was removed and the errors fixed.

Test Plan
=========

CI and also compared the BPF JITed code, which had no changes (minus relative addresses), which was checked with:

```
$ sudo bpftool prog dump jited name dwarf_unwind > /tmp/after
```

```
$ wc -l /tmp/old /tmp/new
  2372 /tmp/old
  2372 /tmp/new
```