### PR TITLE
build: Use clang/llvm 21

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -65,7 +65,9 @@ fn main() {
     let skel = Path::new(PROFILER_SKELETON);
     SkeletonBuilder::new()
         .source(PROFILER_BPF_SOURCE)
-        .clang_args(["-Wextra", "-Wall", "-Werror"])
+        // Older kernels reject the current code if compiled with v3 of the ISA (the default in
+        // LLVM 20+). Select the previous default BPF instruction set.
+        .clang_args(["-mcpu=v1", "-Wextra", "-Wall", "-Werror"])
         .build_and_generate(skel)
         .expect("run skeleton builder");
 

--- a/flake.nix
+++ b/flake.nix
@@ -29,17 +29,17 @@
           clang' = with pkgs; (
             pkgs.writeShellScriptBin "clang" ''
               if [[ "$@" =~ "-target bpf" ]]; then
-                exec ${llvmPackages_19.clang-unwrapped}/bin/clang -I${llvmPackages_19.clang-unwrapped.lib}/lib/clang/19/include "$@"
+                exec ${llvmPackages_21.clang-unwrapped}/bin/clang -I${llvmPackages_21.clang-unwrapped.lib}/lib/clang/21/include "$@"
               else
-                exec ${llvmPackages_19.clang}/bin/clang "$@"
+                exec ${llvmPackages_21.clang}/bin/clang "$@"
               fi
             ''
           );
           buildInputs = with pkgs; [
             clang'
-            llvmPackages_19.libcxx
-            llvmPackages_19.libclang
-            llvmPackages_19.lld
+            llvmPackages_21.libcxx
+            llvmPackages_21.libclang
+            llvmPackages_21.lld
             elfutils'
             zlib.static
             zlib.dev
@@ -58,7 +58,7 @@
             buildInputs = buildInputs;
             nativeBuildInputs = nativeBuildInputs;
             hardeningDisable = [ "all" ];
-            LIBCLANG_PATH = with pkgs; lib.makeLibraryPath [ llvmPackages_19.libclang ];
+            LIBCLANG_PATH = with pkgs; lib.makeLibraryPath [ llvmPackages_21.libclang ];
             LIBBPF_SYS_LIBRARY_PATH = with pkgs; lib.makeLibraryPath [ zlib.static elfutils' ];
           };
           lightswitch = craneLib.buildPackage (
@@ -116,7 +116,7 @@
               graphviz
             ];
             hardeningDisable = [ "all" ];
-            LIBCLANG_PATH = lib.makeLibraryPath [ llvmPackages_19.libclang ];
+            LIBCLANG_PATH = lib.makeLibraryPath [ llvmPackages_21.libclang ];
             LIBBPF_SYS_LIBRARY_PATH = lib.makeLibraryPath [ zlib.static elfutils' ];
             RUST_GDB = "${gdb}/bin/gdb";
           };


### PR DESCRIPTION
Use clang 21, initially released on the 26 August 2025 (1y after clang 19).

The generated code trips the verifier in older kernels we support, after bisecting clang, the offending commit is `[BPF] Make -mcpu=v3 as the default (#107008) ` [0]. The code generated with this version of the ISA isn't too different, but some registers seem to be 16 and 32 bit wide instead of 64. Perhaps the verifier can't prove termination anymore due to this. Forcing these values to be 64 bits seems like a bit of a hack, so let's force v1 of the ISA and the ISA bump can be done later on.

Note that unrolling the loop as previously suggested [1] makes the code size explode, as expected:

```
$ wc -l /tmp/llvm_21_v3 /tmp/llvm_21_v1 /tmp/llvm_21_v1_unrolled
  1748 /tmp/llvm_21_v3
  1800 /tmp/llvm_21_v1
  7948 /tmp/llvm_21_v1_unrolled
 11496 total
```

[0]: https://github.com/llvm/llvm-project/commit/7852ebc088b925ef1c1940cbd56a93d9f8e3e330
[1]: https://github.com/javierhonduco/lightswitch/pull/495

Test Plan
=========

CI