### PR TITLE
unwind: Ensure unwind data is valid

### DIFF
--- a/lightswitch-unwind-info/CHANGELOG.md
+++ b/lightswitch-unwind-info/CHANGELOG.md
@@ -1,3 +1,4 @@
 Unreleased
 ----------
 - Fix user-controlled allocations by setting an upper limit of unwind entries that can be read.
+- Ensure unwind information data is valid. This fixes undefined behaviour when formatting data that can't be represented in the enums.

--- a/lightswitch-unwind-info/src/persist.rs
+++ b/lightswitch-unwind-info/src/persist.rs
@@ -10,7 +10,7 @@ use ring::digest::{Context, SHA256};
 use thiserror::Error;
 
 use crate::compact_unwind_info;
-use crate::types::CompactUnwindRow;
+use crate::types::{CompactUnwindRow, CompactUnwindRowWire};
 
 // To identify this binary file type.
 const MAGIC_NUMBER: u32 = 0x1357531;
@@ -48,7 +48,7 @@ unsafe impl Plain for Header {}
 /// SAFETY: Using packed C representation, which plain needs, and there is
 /// the extra safety layer of the unwind information digest checked in the
 /// read path, in case the data is corrupted.
-unsafe impl Plain for CompactUnwindRow {}
+unsafe impl Plain for CompactUnwindRowWire {}
 
 /// Writes compact information to a given writer.
 pub struct Writer {
@@ -139,8 +139,10 @@ pub enum ReaderError {
     Generic(String),
     #[error("index out of range")]
     OutOfRange,
-    #[error("could not convert between types")]
+    #[error("could not convert between size types")]
     SizeConversion,
+    #[error("raw unwind info contains invalid data")]
+    RowInvalidData,
     #[error("digest does not match")]
     Digest,
 }
@@ -194,7 +196,7 @@ impl<'a> Reader<'a> {
             .map_err(|_| ReaderError::SizeConversion)?;
 
         let mut unwind_info = Vec::with_capacity(unwind_info_len);
-        let mut unwind_row = CompactUnwindRow::default();
+        let mut unwind_row_wire = CompactUnwindRowWire::default();
 
         let unwind_info_data = &self.data[header_size..];
         let mut context = Context::new(&SHA256);
@@ -206,9 +208,13 @@ impl<'a> Reader<'a> {
             if self.check_digest {
                 context.update(unwind_row_data);
             }
-            plain::copy_from_bytes(&mut unwind_row, unwind_row_data)
+            plain::copy_from_bytes(&mut unwind_row_wire, unwind_row_data)
                 .map_err(|e| ReaderError::Generic(format!("{e:?}")))?;
-            unwind_info.push(unwind_row);
+            unwind_info.push(
+                unwind_row_wire
+                    .try_into()
+                    .map_err(|_| ReaderError::RowInvalidData)?,
+            );
         }
 
         if self.check_digest {
@@ -349,5 +355,15 @@ mod tests {
             Reader::new(&buffer, true).unwrap().unwind_info(),
             Err(ReaderError::OutOfRange)
         ));
+    }
+
+    #[test]
+    fn test_bad_wire_conversion() {
+        let wire = CompactUnwindRowWire {
+            cfa_type: u8::MAX,
+            ..CompactUnwindRowWire::default()
+        };
+        let res: Result<CompactUnwindRow, ()> = wire.try_into();
+        assert!(res.is_err());
     }
 }

--- a/lightswitch-unwind-info/src/types.rs
+++ b/lightswitch-unwind-info/src/types.rs
@@ -19,6 +19,26 @@ pub enum CfaType {
     OffsetDidNotFit = 9,
 }
 
+impl TryInto<CfaType> for u8 {
+    type Error = ();
+
+    fn try_into(self) -> Result<CfaType, ()> {
+        match self {
+            0 => Ok(CfaType::Unknown),
+            1 => Ok(CfaType::FramePointerOffset),
+            2 => Ok(CfaType::StackPointerOffset),
+            3 => Ok(CfaType::UnsupportedExpression),
+            4 => Ok(CfaType::Plt1),
+            5 => Ok(CfaType::Plt2),
+            6 => Ok(CfaType::DerefAndAdd),
+            7 => Ok(CfaType::EndFdeMarker),
+            8 => Ok(CfaType::UnsupportedRegisterOffset),
+            9 => Ok(CfaType::OffsetDidNotFit),
+            _ => Err(()),
+        }
+    }
+}
+
 #[repr(u8)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub enum RbpType {
@@ -34,6 +54,35 @@ pub enum RbpType {
     Arm64ReturnAddressElsewhere = 8,
 }
 
+impl TryInto<RbpType> for u8 {
+    type Error = ();
+
+    fn try_into(self) -> Result<RbpType, ()> {
+        match self {
+            0 => Ok(RbpType::Unchanged),
+            1 => Ok(RbpType::CfaOffset),
+            2 => Ok(RbpType::Register),
+            3 => Ok(RbpType::Expression),
+            4 => Ok(RbpType::UndefinedReturnAddress),
+            5 => Ok(RbpType::OffsetDidNotFit),
+            6 => Ok(RbpType::Arm64ReturnAddressLr),
+            7 => Ok(RbpType::Arm64ReturnAddressFrame),
+            8 => Ok(RbpType::Arm64ReturnAddressElsewhere),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[repr(C, packed)]
+pub struct CompactUnwindRowWire {
+    pub pc: u64,
+    pub cfa_type: u8,
+    pub rbp_type: u8,
+    pub cfa_offset: u16,
+    pub rbp_offset: i16,
+}
+
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 #[repr(C, packed)]
 pub struct CompactUnwindRow {
@@ -42,6 +91,20 @@ pub struct CompactUnwindRow {
     pub rbp_type: RbpType,
     pub cfa_offset: u16,
     pub rbp_offset: i16,
+}
+
+impl TryInto<CompactUnwindRow> for CompactUnwindRowWire {
+    type Error = ();
+
+    fn try_into(self) -> Result<CompactUnwindRow, ()> {
+        Ok(CompactUnwindRow {
+            pc: self.pc,
+            cfa_type: self.cfa_type.try_into()?,
+            rbp_type: self.rbp_type.try_into()?,
+            cfa_offset: self.cfa_offset,
+            rbp_offset: self.rbp_offset,
+        })
+    }
 }
 
 impl CompactUnwindRow {


### PR DESCRIPTION
There was undefined behaviour on the debug impl due to enum variants not being validated.

Test Plan
=========

Added test