### PR TITLE
cli: Expose Firefox Profiler format properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-v0.5.0
+Unreleased
 ----------
+- Expose Firefox profiler collector as a format in the CLI
+
+v0.5.0
+------
 - Fix bug preventing profiling of processes in a different pid namespace than lightswitch's
 - Add support for Pyroscope
 - Cache object files by file_id to avoid reparsing them

--- a/README.md
+++ b/README.md
@@ -34,13 +34,7 @@ As a CLI, **lightswitch** can be run with:
 $ sudo lightswitch
 ```
 
-Stop it with <kbd>Ctrl</kbd>+<kbd>C</kbd>, or alternatively, pass a `--duration` in seconds. By default, a flamegraph in SVG format will be written to disk. Pprof is also supported with `--profile-format=pprof`. By default the whole machine will be profiled which can be overriden with `--pids`.
-
-With Docker:
-
-```shell
-$ docker run -it --privileged --pid=host -v /sys:/sys -v $PWD:/profiles -v /tmp/lightswitch ghcr.io/javierhonduco/lightswitch:main-$LIGHTSWITCH_SHA1 --profile-path=/profiles
-```
+Stop it with <kbd>Ctrl</kbd>+<kbd>C</kbd>, or alternatively, pass a `--duration` in seconds. By default, a flamegraph in SVG format will be written to disk. Profiles in the Firefox Profiler can be produced with `--profile-format=firefox` and visualized with `ligthswitch server`. Pprof is also supported with `--profile-format=pprof`. By default the whole machine will be profiled which can be overriden with `--pids`.
 
 Development
 -----------

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -24,6 +24,7 @@ pub(crate) enum ProfileFormat {
     None,
     #[default]
     FlameGraph,
+    Firefox,
     Pprof,
 }
 
@@ -42,7 +43,6 @@ pub(crate) enum ProfileSender {
     LocalDisk,
     Remote,
     Pyroscope,
-    Firefox,
 }
 
 #[derive(PartialEq, clap::ValueEnum, Debug, Clone, Default)]

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -353,7 +353,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     let collector: Arc<Mutex<Box<dyn Collector + Send>>> =
         Arc::new(Mutex::new(match args.sender {
             ProfileSender::None => Box::new(NullCollector::new()),
-            ProfileSender::LocalDisk => Box::new(AggregatorCollector::new()),
+            ProfileSender::LocalDisk => match args.profile_format {
+                ProfileFormat::Firefox => Box::new(FirefoxProfilerCollector::new(
+                    "firefox-profiler.json",
+                    args.sample_freq,
+                    metadata_provider.clone(),
+                )),
+                _ => Box::new(AggregatorCollector::new()),
+            },
             ProfileSender::Remote => Box::new(StreamingCollector::new(
                 token,
                 args.symbolizer == Symbolizer::Local,
@@ -372,11 +379,6 @@ fn main() -> Result<(), Box<dyn Error>> {
                 metadata_provider.clone(),
                 args.node_name.clone().unwrap_or_default(),
             )),
-            ProfileSender::Firefox => Box::new(FirefoxProfilerCollector::new(
-                "firefox-profiler.json",
-                args.sample_freq,
-                metadata_provider.clone(),
-            )),
         }));
 
     let mut p = Profiler::new(
@@ -392,10 +394,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // The senders below send the profiles directly.
     match args.sender {
-        ProfileSender::Remote
-        | ProfileSender::Pyroscope
-        | ProfileSender::Firefox
-        | ProfileSender::None => {
+        ProfileSender::Remote | ProfileSender::Pyroscope | ProfileSender::None => {
             return Ok(());
         }
         _ => {}
@@ -460,6 +459,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 }
             }
         }
+        ProfileFormat::Firefox => {} // Handled separately, as a different collector
         ProfileFormat::None => {}
     }
 
@@ -564,7 +564,7 @@ mod tests {
                   Output file for Flame Graph in SVG format
                   
                   [default: flame-graph]
-                  [possible values: none, flame-graph, pprof]
+                  [possible values: none, flame-graph, firefox, pprof]
 
               --flamegraph-aggregation <FLAMEGRAPH_AGGREGATION>
                   What information to show in the flamegraph. Won't do anything for other profile formats
@@ -586,7 +586,6 @@ mod tests {
                   - local-disk
                   - remote
                   - pyroscope
-                  - firefox
                   
                   [default: local-disk]
 


### PR DESCRIPTION
The current code is a bit silly, but let's at least expose the firefox profiler format as what it is, a format, rather than the leaky messy code of being a separate collector.

Test Plan
=========

CI