### PR TITLE
profile: Add Perfetto trace output and viewer integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 flame.svg
 profile.pb
 firefox-profiler.json
+profile.pftrace
 **/bpf/*_skel.rs
 .vmtest.log
 /result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 - Expose Firefox profiler collector as a format in the CLI
+- Add Perfetto trace output and local Perfetto UI serving
 
 v0.5.0
 ------

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,6 +1488,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2428,6 +2434,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mini-moka"
@@ -4129,11 +4145,19 @@ dependencies = [
  "base64",
  "bitflags 2.13.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
  "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ serde_json = "1.0.150"
 axum = "0.8.9"
 tokio =  { version = "1.52.3", features = ["rt-multi-thread"] }
 urlencoding = "2.1.3"
-tower-http = { version = "0.6.11", features = ["cors"] }
+tower-http = { version = "0.6.11", features = ["cors", "fs"] }
 
 [dev-dependencies]
 assert_cmd = { version = "2.2.0" }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,13 @@ As a CLI, **lightswitch** can be run with:
 $ sudo lightswitch
 ```
 
-Stop it with <kbd>Ctrl</kbd>+<kbd>C</kbd>, or alternatively, pass a `--duration` in seconds. By default, a flamegraph in SVG format will be written to disk. Profiles in the Firefox Profiler can be produced with `--profile-format=firefox` and visualized with `ligthswitch server`. Pprof is also supported with `--profile-format=pprof`. By default the whole machine will be profiled which can be overriden with `--pids`.
+Stop it with <kbd>Ctrl</kbd>+<kbd>C</kbd>, or alternatively, pass a `--duration` in seconds. By default, a flamegraph in SVG format will be written to disk. Pprof, Firefox Profiler, and Perfetto traces are also supported with `--profile-format=pprof`, `--profile-format=firefox`, and `--profile-format=perfetto`, respectively. Completed Firefox and Perfetto profiles can be visualized with `lightswitch server`. The server automatically selects `firefox-profiler.json` or `profile.pftrace` when exactly one exists, or accepts another path with `--profile <PROFILE>`. By default the whole machine will be profiled, which can be overridden with `--pids`.
+
+For example, open the default completed profile in its native web viewer with:
+
+```shell
+$ lightswitch server
+```
 
 Development
 -----------

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -25,7 +25,14 @@ pub(crate) enum ProfileFormat {
     #[default]
     FlameGraph,
     Firefox,
+    Perfetto,
     Pprof,
+}
+
+#[derive(clap::ValueEnum, Debug, Clone, Copy)]
+pub(crate) enum ServerProfileFormat {
+    Firefox,
+    Perfetto,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Default, PartialEq)]
@@ -70,6 +77,13 @@ pub(crate) enum Commands {
     },
     SystemInfo,
     Server {
+        /// Completed profile to serve. Detects the default Firefox or Perfetto
+        /// output when omitted.
+        #[arg(long)]
+        profile: Option<PathBuf>,
+        /// Profile format. Inferred from .json or .pftrace when omitted.
+        #[arg(long, value_enum)]
+        format: Option<ServerProfileFormat>,
         #[arg(long)]
         no_open: bool,
     },

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1,5 +1,6 @@
 use core::str;
 use std::error::Error;
+use std::ffi::CString;
 use std::fs::File;
 use std::io::IsTerminal;
 use std::io::Write;
@@ -15,14 +16,13 @@ use clap::Parser;
 use crossbeam_channel::bounded;
 use crossbeam_channel::tick;
 use inferno::flamegraph;
-use lightswitch::collector::FirefoxProfilerCollector;
 use lightswitch::collector::{
-    AggregatorCollector, Collector, LiveCollector, NullCollector, PyroscopeCollector,
-    StreamingCollector,
+    AggregatorCollector, Collector, FirefoxProfilerCollector, LiveCollector, NullCollector,
+    PerfettoCollector, PyroscopeCollector, StreamingCollector,
 };
 use lightswitch::debug_info::DebugInfoManager;
 use lightswitch::profile::symbolize_profile;
-use nix::unistd::Uid;
+use nix::unistd::{Gid, Uid};
 use tracing::{debug, error, info, Level};
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::FmtSubscriber;
@@ -39,7 +39,7 @@ use lightswitch::debug_info::{
 use lightswitch::kernel::kernel_build_id;
 use lightswitch::profile::{fold_profile, to_pprof};
 use lightswitch::profiler::{Profiler, ProfilerConfig};
-use lightswitch::server::start_server;
+use lightswitch::server::{find_default_profile, start_profile_server, ProfileFileFormat};
 use lightswitch_object::kernel::kaslr_offset;
 use lightswitch_object::ObjectFile;
 use lightswitch_unwind_info::compact_unwind_info;
@@ -56,6 +56,7 @@ use crate::args::FlamegraphAggregation;
 use crate::args::LoggingLevel;
 use crate::args::ProfileFormat;
 use crate::args::ProfileSender;
+use crate::args::ServerProfileFormat;
 use crate::args::Symbolizer;
 use crate::killswitch::KillSwitch;
 
@@ -157,25 +158,50 @@ fn main() -> Result<(), Box<dyn Error>> {
 
             return Ok(());
         }
-        Some(Commands::Server { no_open }) => {
+        Some(Commands::Server {
+            profile,
+            format,
+            no_open,
+        }) => {
             // If root, change user to the one that invoked `sudo` as we want to
             // open the browser with that user.
             if nix::unistd::geteuid().is_root() {
-                let target_uid = std::env::var("SUDO_UID")
-                    .expect("SUDO_UID not set")
-                    .parse::<u32>()
-                    .expect("SUDO_UID could not be parsed");
-
-                nix::unistd::setuid(Uid::from_raw(target_uid)).unwrap();
+                let target_uid = Uid::from_raw(std::env::var("SUDO_UID")?.parse()?);
+                let target_gid = Gid::from_raw(std::env::var("SUDO_GID")?.parse()?);
+                let target_user = CString::new(std::env::var("SUDO_USER")?)?;
+                nix::unistd::initgroups(&target_user, target_gid)?;
+                nix::unistd::setgid(target_gid)?;
+                nix::unistd::setuid(target_uid)?;
             }
 
-            let port = 3000;
-            let url = format!("http://localhost:{port}");
-            println!("Listening on {url}");
+            let profile = match profile {
+                Some(profile) => profile,
+                None => find_default_profile(&PathBuf::new())?,
+            };
+            let format = match format {
+                Some(ServerProfileFormat::Firefox) => ProfileFileFormat::Firefox,
+                Some(ServerProfileFormat::Perfetto) => ProfileFileFormat::Perfetto,
+                None => ProfileFileFormat::from_path(&profile).ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "cannot infer profile format; use --format firefox or --format perfetto",
+                    )
+                })?,
+            };
+            if !profile.is_file() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("profile not found: {}", profile.to_string_lossy()),
+                )
+                .into());
+            }
+            let port = format.default_port();
+            let url = format!("http://127.0.0.1:{port}");
+            println!("Serving {} at {url}", profile.to_string_lossy());
             if !no_open {
                 open_browser(&url);
             }
-            start_server(port);
+            start_profile_server(port, profile, format)?;
             return Ok(());
         }
     }
@@ -350,14 +376,26 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     });
 
+    let profile_path = |default_name: &str| {
+        args.profile_path.clone().unwrap_or_default().join(
+            args.profile_name
+                .clone()
+                .unwrap_or_else(|| default_name.into()),
+        )
+    };
     let collector: Arc<Mutex<Box<dyn Collector + Send>>> =
         Arc::new(Mutex::new(match args.sender {
             ProfileSender::None => Box::new(NullCollector::new()),
             ProfileSender::LocalDisk => match args.profile_format {
                 ProfileFormat::Firefox => Box::new(FirefoxProfilerCollector::new(
-                    "firefox-profiler.json",
+                    profile_path(ProfileFileFormat::Firefox.default_profile_name()),
                     args.sample_freq,
                     metadata_provider.clone(),
+                )),
+                ProfileFormat::Perfetto => Box::new(PerfettoCollector::new(
+                    profile_path(ProfileFileFormat::Perfetto.default_profile_name()),
+                    args.sample_freq,
+                    args.symbolizer == Symbolizer::Local,
                 )),
                 _ => Box::new(AggregatorCollector::new()),
             },
@@ -398,6 +436,14 @@ fn main() -> Result<(), Box<dyn Error>> {
             return Ok(());
         }
         _ => {}
+    }
+
+    // Timeline formats preserve and write raw samples in dedicated collectors.
+    if matches!(
+        &args.profile_format,
+        ProfileFormat::Firefox | ProfileFormat::Perfetto
+    ) {
+        return Ok(());
     }
 
     // Otherwise let's symbolize the profile and write it to disk.
@@ -459,7 +505,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 }
             }
         }
-        ProfileFormat::Firefox => {} // Handled separately, as a different collector
+        ProfileFormat::Firefox | ProfileFormat::Perfetto => unreachable!("handled above"),
         ProfileFormat::None => {}
     }
 
@@ -572,7 +618,7 @@ mod tests {
                   Output file for Flame Graph in SVG format
                   
                   [default: flame-graph]
-                  [possible values: none, flame-graph, firefox, pprof]
+                  [possible values: none, flame-graph, firefox, perfetto, pprof]
 
               --flamegraph-aggregation <FLAMEGRAPH_AGGREGATION>
                   What information to show in the flamegraph. Won't do anything for other profile formats

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -5,6 +5,7 @@ use prost::Message;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::io::{BufWriter, Write};
+use std::path::PathBuf;
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -25,7 +26,9 @@ use crate::profile::{
     fold_profile, symbolize_profile, to_pprof, AggregatedSample, SymbolizedFrame,
 };
 use crate::profile::{raw_to_processed, RawSample};
-use crate::profile::{AggregatedProfile, RawAggregatedProfile, RawAggregatedSample};
+use crate::profile::{
+    write_perfetto, AggregatedProfile, RawAggregatedProfile, RawAggregatedSample, TimestampedSample,
+};
 use crate::NAME_AND_VERSION;
 
 pub trait Collector {
@@ -541,8 +544,106 @@ impl Collector for LiveCollector {
     }
 }
 
+pub struct PerfettoCollector {
+    profile_path: PathBuf,
+    sample_freq: u64,
+    local_symbolizer: bool,
+    walltime_at_system_boot: u64,
+    samples: Vec<TimestampedSample>,
+    procs: HashMap<i32, ProcessInfo>,
+    objs: HashMap<ExecutableId, ObjectFileInfo>,
+}
+
+impl PerfettoCollector {
+    pub fn new(profile_path: PathBuf, sample_freq: u64, local_symbolizer: bool) -> Self {
+        let walltime_at_system_boot = procfs::boot_time()
+            .expect("read system boot time")
+            .timestamp_nanos_opt()
+            .expect("system boot time fits in nanoseconds")
+            as u64;
+        Self {
+            profile_path,
+            sample_freq,
+            local_symbolizer,
+            walltime_at_system_boot,
+            samples: Vec::new(),
+            procs: HashMap::new(),
+            objs: HashMap::new(),
+        }
+    }
+}
+
+impl Collector for PerfettoCollector {
+    fn collect(
+        &mut self,
+        samples: Vec<RawSample>,
+        procs: &HashMap<i32, ProcessInfo>,
+        objs: &HashMap<ExecutableId, ObjectFileInfo>,
+    ) {
+        let mut timestamps = Vec::with_capacity(samples.len());
+        let mut profile = Vec::with_capacity(samples.len());
+        for sample in samples {
+            let Some(timestamp) = sample
+                .collected_at
+                .checked_sub(self.walltime_at_system_boot)
+            else {
+                debug!(
+                    timestamp = sample.collected_at,
+                    "Perfetto sample timestamp predates system boot"
+                );
+                continue;
+            };
+            let raw_sample = RawAggregatedSample { sample, count: 1 };
+            match raw_sample.process(procs, objs) {
+                Ok(processed_sample) => {
+                    timestamps.push(timestamp);
+                    profile.push(processed_sample);
+                }
+                Err(error) => debug!(?error, "failed to process sample for Perfetto output"),
+            }
+        }
+
+        let profile = if self.local_symbolizer {
+            symbolize_profile(&profile, procs, objs)
+        } else {
+            profile
+        };
+        self.samples.extend(
+            timestamps
+                .into_iter()
+                .zip(profile)
+                .map(|(timestamp, sample)| TimestampedSample { timestamp, sample }),
+        );
+    }
+
+    fn finish(
+        &self,
+    ) -> (
+        AggregatedProfile,
+        &HashMap<i32, ProcessInfo>,
+        &HashMap<ExecutableId, ObjectFileInfo>,
+    ) {
+        match File::create(&self.profile_path).and_then(|file| {
+            let mut writer = BufWriter::new(file);
+            write_perfetto(&mut writer, &self.samples, self.sample_freq)?;
+            writer.flush()
+        }) {
+            Ok(()) => eprintln!(
+                "Perfetto profile successfully written to {}",
+                self.profile_path.to_string_lossy()
+            ),
+            Err(error) => tracing::error!(
+                "failed to write Perfetto profile to {}: {error}",
+                self.profile_path.to_string_lossy()
+            ),
+        }
+
+        (AggregatedProfile::new(), &self.procs, &self.objs)
+    }
+}
+
 pub struct FirefoxProfilerCollector {
-    profile_name: String,
+    profile_path: PathBuf,
     sample_freq: u64,
     samples: Vec<AggregatedSample>,
     timestamps: Vec<u64>,
@@ -554,12 +655,12 @@ pub struct FirefoxProfilerCollector {
 
 impl FirefoxProfilerCollector {
     pub fn new(
-        profile_name: &str,
+        profile_path: impl Into<PathBuf>,
         sample_freq: u64,
         meta: ThreadSafeGlobalMetadataProvider,
     ) -> Self {
         FirefoxProfilerCollector {
-            profile_name: profile_name.to_string(),
+            profile_path: profile_path.into(),
             sample_freq,
             samples: vec![],
             timestamps: vec![],
@@ -716,7 +817,7 @@ impl Collector for FirefoxProfilerCollector {
             );
         }
 
-        let file = File::create(&self.profile_name).unwrap();
+        let file = File::create(&self.profile_path).unwrap();
         serde_json::to_writer(&mut BufWriter::new(file), &ff_profile).unwrap();
 
         (AggregatedProfile::new(), &self.procs, &self.objs)

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -1,7 +1,9 @@
 mod convert;
 mod frame;
+mod perfetto;
 mod sample;
 
 pub use convert::*;
 pub use frame::*;
+pub use perfetto::*;
 pub use sample::*;

--- a/src/profile/perfetto.rs
+++ b/src/profile/perfetto.rs
@@ -1,0 +1,505 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::io::{self, Write};
+
+use crate::profile::{AggregatedSample, Frame};
+
+// Values below are from Perfetto's stable profiling API at
+// google/perfetto@3babdfbba1f84310b364a96383deae6c27548bf5.
+const TRUSTED_PACKET_SEQUENCE_ID: u64 = 1;
+
+#[derive(Clone, Copy)]
+#[repr(u64)]
+enum SequenceFlag {
+    IncrementalStateCleared = 1,
+    NeedsIncrementalState = 2,
+}
+
+#[derive(Clone, Copy)]
+#[repr(u64)]
+enum BuiltinClock {
+    Boottime = 6,
+}
+
+#[derive(Clone, Copy, Hash, Eq, PartialEq)]
+#[repr(u64)]
+enum FrameKind {
+    Native = 1,
+    Kernel = 2,
+}
+
+#[derive(Clone, Copy)]
+#[repr(u64)]
+enum CounterUnit {
+    Nanoseconds = 1,
+}
+
+#[derive(Clone, Copy)]
+#[repr(u64)]
+enum WireType {
+    Varint = 0,
+    LengthDelimited = 2,
+}
+
+#[derive(Debug)]
+pub struct TimestampedSample {
+    /// Nanoseconds from `CLOCK_BOOTTIME`, matching `bpf_ktime_get_boot_ns`.
+    pub timestamp: u64,
+    pub sample: AggregatedSample,
+}
+
+#[derive(Clone, Copy, Hash, Eq, PartialEq)]
+struct FrameKey {
+    function_name_iid: u64,
+    source_path_iid: Option<u64>,
+    line: Option<u32>,
+    kind: FrameKind,
+}
+
+#[derive(Default)]
+struct Interner {
+    function_names: HashMap<String, u64>,
+    source_paths: HashMap<String, u64>,
+    frames: HashMap<FrameKey, u64>,
+    callstacks: HashMap<Vec<u64>, u64>,
+    task_contexts: HashMap<(u32, u32), u64>,
+}
+
+impl Interner {
+    fn string(values: &mut HashMap<String, u64>, value: Cow<'_, str>) -> u64 {
+        if let Some(iid) = values.get(value.as_ref()) {
+            return *iid;
+        }
+        let iid = values.len() as u64 + 1;
+        values.insert(value.into_owned(), iid);
+        iid
+    }
+
+    fn frame(&mut self, frame: &Frame, kind: FrameKind) -> u64 {
+        let (name, source_path, line) = match &frame.symbolization_result {
+            Some(Ok(symbolized)) => (
+                Cow::Borrowed(symbolized.name.as_str()),
+                symbolized.filename.as_deref(),
+                symbolized.line,
+            ),
+            Some(Err(error)) => (Cow::Owned(error.to_string()), None, None),
+            None => (
+                Cow::Owned(format!("0x{:x}", frame.virtual_address)),
+                None,
+                None,
+            ),
+        };
+        let key = FrameKey {
+            function_name_iid: Self::string(&mut self.function_names, name),
+            source_path_iid: source_path
+                .map(|path| Self::string(&mut self.source_paths, Cow::Borrowed(path))),
+            line,
+            kind,
+        };
+        if let Some(iid) = self.frames.get(&key) {
+            return *iid;
+        }
+        let iid = self.frames.len() as u64 + 1;
+        self.frames.insert(key, iid);
+        iid
+    }
+
+    fn sample(&mut self, sample: &AggregatedSample) -> Option<(u64, u64)> {
+        let task = (
+            u32::try_from(sample.pid).ok()?,
+            u32::try_from(sample.tid).ok()?,
+        );
+        let task_iid = if let Some(iid) = self.task_contexts.get(&task) {
+            *iid
+        } else {
+            let iid = self.task_contexts.len() as u64 + 1;
+            self.task_contexts.insert(task, iid);
+            iid
+        };
+
+        // Lightswitch stacks are leaf-first; Perfetto expects bottom-first.
+        let mut frame_ids = Vec::with_capacity(sample.ustack.len() + sample.kstack.len());
+        for frame in sample.ustack.iter().rev() {
+            frame_ids.push(self.frame(frame, FrameKind::Native));
+        }
+        for frame in sample.kstack.iter().rev() {
+            frame_ids.push(self.frame(frame, FrameKind::Kernel));
+        }
+        if frame_ids.is_empty() {
+            return None;
+        }
+
+        let callstack_iid = if let Some(iid) = self.callstacks.get(&frame_ids) {
+            *iid
+        } else {
+            let iid = self.callstacks.len() as u64 + 1;
+            self.callstacks.insert(frame_ids, iid);
+            iid
+        };
+        Some((task_iid, callstack_iid))
+    }
+
+    fn encode(&self, out: &mut Vec<u8>) {
+        for (value, iid) in &self.function_names {
+            message(out, 5, |out| {
+                field(out, 1, *iid);
+                bytes(out, 2, value.as_bytes());
+            });
+        }
+        for (frame, iid) in &self.frames {
+            message(out, 6, |out| {
+                field(out, 1, *iid);
+                field(out, 2, frame.function_name_iid);
+                if let Some(iid) = frame.source_path_iid {
+                    field(out, 5, iid);
+                }
+                if let Some(line) = frame.line {
+                    field(out, 6, u64::from(line));
+                }
+                field(out, 7, frame.kind as u64);
+            });
+        }
+        for (frame_ids, iid) in &self.callstacks {
+            message(out, 7, |out| {
+                field(out, 1, *iid);
+                for frame_id in frame_ids {
+                    // Perfetto's proto2 field is repeated and unpacked.
+                    field(out, 2, *frame_id);
+                }
+            });
+        }
+        for (value, iid) in &self.source_paths {
+            message(out, 18, |out| {
+                field(out, 1, *iid);
+                bytes(out, 2, value.as_bytes());
+            });
+        }
+        for ((pid, tid), iid) in &self.task_contexts {
+            message(out, 48, |out| {
+                field(out, 1, *iid);
+                field(out, 2, u64::from(*pid));
+                field(out, 3, u64::from(*tid));
+            });
+        }
+    }
+}
+
+fn varint_bytes(mut value: u64) -> ([u8; 10], usize) {
+    let mut bytes = [0; 10];
+    let mut len = 0;
+    loop {
+        bytes[len] = (value as u8 & 0x7f) | if value >= 0x80 { 0x80 } else { 0 };
+        len += 1;
+        value >>= 7;
+        if value == 0 {
+            return (bytes, len);
+        }
+    }
+}
+
+fn varint(out: &mut Vec<u8>, value: u64) {
+    let (bytes, len) = varint_bytes(value);
+    out.extend_from_slice(&bytes[..len]);
+}
+
+fn field(out: &mut Vec<u8>, id: u32, value: u64) {
+    varint(out, (u64::from(id) << 3) | WireType::Varint as u64);
+    varint(out, value);
+}
+
+fn bytes(out: &mut Vec<u8>, id: u32, value: &[u8]) {
+    varint(out, (u64::from(id) << 3) | WireType::LengthDelimited as u64);
+    varint(out, value.len() as u64);
+    out.extend_from_slice(value);
+}
+
+/// Reserves the longest possible length prefix, encodes in place, and closes
+/// the unused prefix bytes afterward. This avoids a buffer per nested message.
+fn message(out: &mut Vec<u8>, id: u32, encode: impl FnOnce(&mut Vec<u8>)) {
+    varint(out, (u64::from(id) << 3) | WireType::LengthDelimited as u64);
+    let length_offset = out.len();
+    out.resize(length_offset + 10, 0);
+    let payload_offset = out.len();
+    encode(out);
+
+    let payload_len = out.len() - payload_offset;
+    let (length, length_len) = varint_bytes(payload_len as u64);
+    out.copy_within(payload_offset.., length_offset + length_len);
+    out.truncate(out.len() - (10 - length_len));
+    out[length_offset..length_offset + length_len].copy_from_slice(&length[..length_len]);
+}
+
+fn encode_defaults(out: &mut Vec<u8>) {
+    field(out, 58, BuiltinClock::Boottime as u64);
+    message(out, 100, |out| {
+        bytes(out, 1, b"lightswitch");
+        message(out, 2, |out| {
+            bytes(out, 2, b"cpu-clock");
+            field(out, 3, CounterUnit::Nanoseconds as u64);
+            bytes(out, 6, b"CPU time represented by each periodic sample");
+        });
+    });
+}
+
+fn encode_metadata_packet(out: &mut Vec<u8>, interner: &Interner) {
+    field(out, 10, TRUSTED_PACKET_SEQUENCE_ID);
+    message(out, 12, |out| interner.encode(out));
+    field(out, 13, SequenceFlag::IncrementalStateCleared as u64);
+    message(out, 59, encode_defaults);
+}
+
+fn encode_sample_packet(
+    out: &mut Vec<u8>,
+    timestamp: u64,
+    task_context_iid: u64,
+    callstack_iid: u64,
+    primary_weight: u64,
+) {
+    field(out, 8, timestamp);
+    field(out, 10, TRUSTED_PACKET_SEQUENCE_ID);
+    field(out, 13, SequenceFlag::NeedsIncrementalState as u64);
+    message(out, 135, |out| {
+        field(out, 2, task_context_iid);
+        field(out, 6, callstack_iid);
+        field(out, 11, primary_weight);
+    });
+}
+
+fn write_packet<W: Write>(writer: &mut W, packet: &[u8]) -> io::Result<()> {
+    let (key, key_len) = varint_bytes((1u64 << 3) | WireType::LengthDelimited as u64);
+    let (length, length_len) = varint_bytes(packet.len() as u64);
+    writer.write_all(&key[..key_len])?;
+    writer.write_all(&length[..length_len])?;
+    writer.write_all(packet)
+}
+
+/// Writes samples as Perfetto `StackSample` packets without generated protobuf
+/// types or a whole-trace output buffer.
+pub fn write_perfetto<W: Write>(
+    writer: &mut W,
+    samples: &[TimestampedSample],
+    sample_frequency_hz: u64,
+) -> io::Result<()> {
+    let mut interner = Interner::default();
+    for sample in samples {
+        interner.sample(&sample.sample);
+    }
+
+    let mut packet = Vec::new();
+    encode_metadata_packet(&mut packet, &interner);
+    write_packet(writer, &packet)?;
+
+    let primary_weight = 1_000_000_000 / sample_frequency_hz.max(1);
+    for sample in samples {
+        let Some((task_context_iid, callstack_iid)) = interner.sample(&sample.sample) else {
+            continue;
+        };
+        packet.clear();
+        encode_sample_packet(
+            &mut packet,
+            sample.timestamp,
+            task_context_iid,
+            callstack_iid,
+            primary_weight,
+        );
+        write_packet(writer, &packet)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::profile::{SymbolizationError, SymbolizedFrame};
+
+    #[derive(Debug)]
+    enum Value<'a> {
+        Varint(u64),
+        Bytes(&'a [u8]),
+    }
+
+    fn decode_varint(input: &mut &[u8]) -> u64 {
+        let mut value = 0;
+        for shift in (0..70).step_by(7) {
+            let byte = input[0];
+            *input = &input[1..];
+            value |= u64::from(byte & 0x7f) << shift;
+            if byte & 0x80 == 0 {
+                return value;
+            }
+        }
+        panic!("invalid varint");
+    }
+
+    fn decode_fields(mut input: &[u8]) -> Vec<(u32, Value<'_>)> {
+        let mut fields = Vec::new();
+        while !input.is_empty() {
+            let key = decode_varint(&mut input);
+            let value = match key & 7 {
+                wire if wire == WireType::Varint as u64 => Value::Varint(decode_varint(&mut input)),
+                wire if wire == WireType::LengthDelimited as u64 => {
+                    let len = decode_varint(&mut input) as usize;
+                    let (value, rest) = input.split_at(len);
+                    input = rest;
+                    Value::Bytes(value)
+                }
+                wire => panic!("unsupported wire type {wire}"),
+            };
+            fields.push(((key >> 3) as u32, value));
+        }
+        fields
+    }
+
+    fn byte_field<'a>(fields: &'a [(u32, Value<'a>)], id: u32) -> &'a [u8] {
+        fields
+            .iter()
+            .find_map(|(field, value)| match (*field, value) {
+                (field, Value::Bytes(value)) if field == id => Some(*value),
+                _ => None,
+            })
+            .unwrap()
+    }
+
+    fn int_field(fields: &[(u32, Value<'_>)], id: u32) -> u64 {
+        fields
+            .iter()
+            .find_map(|(field, value)| match (*field, value) {
+                (field, Value::Varint(value)) if field == id => Some(*value),
+                _ => None,
+            })
+            .unwrap()
+    }
+
+    fn frame(address: u64, name: &str, filename: Option<&str>, line: Option<u32>) -> Frame {
+        Frame {
+            virtual_address: address,
+            file_offset: Some(address),
+            symbolization_result: Some(Ok(SymbolizedFrame::new(
+                name.to_string(),
+                false,
+                filename.map(str::to_string),
+                line,
+            ))),
+        }
+    }
+
+    #[test]
+    fn writes_interned_samples_in_collection_order() {
+        let samples = vec![
+            TimestampedSample {
+                timestamp: 200,
+                sample: AggregatedSample {
+                    pid: 42,
+                    tid: 43,
+                    ustack: vec![
+                        frame(3, "leaf", Some("sample.rs"), Some(30)),
+                        frame(2, "caller", Some("sample.rs"), Some(20)),
+                        frame(1, "main", Some("sample.rs"), Some(10)),
+                    ],
+                    kstack: vec![frame(5, "entry_SYSCALL", None, None)],
+                    count: 1,
+                },
+            },
+            TimestampedSample {
+                timestamp: 100,
+                sample: AggregatedSample {
+                    pid: 42,
+                    tid: 43,
+                    ustack: vec![frame(3, "leaf", Some("sample.rs"), Some(30))],
+                    kstack: vec![],
+                    count: 1,
+                },
+            },
+        ];
+
+        let mut encoded = Vec::new();
+        write_perfetto(&mut encoded, &samples, 20).unwrap();
+        let packets = decode_fields(&encoded);
+        assert_eq!(packets.len(), 3);
+
+        let metadata = decode_fields(byte_field(&packets, 1));
+        assert_eq!(
+            int_field(&metadata, 13),
+            SequenceFlag::IncrementalStateCleared as u64
+        );
+        let defaults = decode_fields(byte_field(&metadata, 59));
+        assert_eq!(int_field(&defaults, 58), BuiltinClock::Boottime as u64);
+        let interned = decode_fields(byte_field(&metadata, 12));
+        assert_eq!(interned.iter().filter(|(field, _)| *field == 5).count(), 4);
+        assert_eq!(interned.iter().filter(|(field, _)| *field == 6).count(), 4);
+        assert_eq!(interned.iter().filter(|(field, _)| *field == 7).count(), 2);
+        assert_eq!(
+            interned
+                .iter()
+                .filter(|(field, _)| { *field == 48 })
+                .count(),
+            1
+        );
+
+        for (packet, timestamp) in packets[1..].iter().zip([200, 100]) {
+            let packet = decode_fields(match packet {
+                (field, Value::Bytes(packet)) if *field == 1 => packet,
+                _ => panic!("expected trace packet"),
+            });
+            assert_eq!(int_field(&packet, 8), timestamp);
+            assert_eq!(
+                int_field(&packet, 13),
+                SequenceFlag::NeedsIncrementalState as u64
+            );
+            let sample = decode_fields(byte_field(&packet, 135));
+            assert_eq!(int_field(&sample, 11), 50_000_000);
+        }
+    }
+
+    #[test]
+    fn names_unsymbolized_and_failed_frames() {
+        let sample = TimestampedSample {
+            timestamp: 1,
+            sample: AggregatedSample {
+                pid: 1,
+                tid: 1,
+                ustack: vec![
+                    Frame {
+                        virtual_address: 0x123,
+                        file_offset: None,
+                        symbolization_result: None,
+                    },
+                    Frame {
+                        virtual_address: 0x456,
+                        file_offset: None,
+                        symbolization_result: Some(Err(SymbolizationError::Generic(
+                            "missing symbols".to_string(),
+                        ))),
+                    },
+                ],
+                kstack: vec![],
+                count: 1,
+            },
+        };
+
+        let mut interner = Interner::default();
+        interner.sample(&sample.sample);
+        assert!(interner.function_names.contains_key("0x123"));
+        assert!(interner
+            .function_names
+            .contains_key("Symbolization error missing symbols"));
+    }
+
+    #[test]
+    fn encodes_varint_boundaries() {
+        let mut encoded = Vec::new();
+        for value in [0, 127, 128, u64::MAX] {
+            varint(&mut encoded, value);
+        }
+        assert_eq!(
+            encoded,
+            [
+                &[0][..],
+                &[127][..],
+                &[128, 1][..],
+                &[255, 255, 255, 255, 255, 255, 255, 255, 255, 1][..],
+            ]
+            .concat()
+        );
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,53 +1,215 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
 use axum::http::HeaderValue;
-use axum::{body::Body, http::Response};
-use axum::{http::header, response::Html, routing::get, Router};
+use axum::response::Html;
+use axum::routing::get;
+use axum::Router;
 use reqwest::Method;
-use std::{fs::File, io::Read};
+use tower_http::cors::CorsLayer;
+use tower_http::services::ServeFile;
+use uuid::Uuid;
 
 const FIREFOX_PROFILER_URL: &str = "https://profiler.firefox.com";
+const PERFETTO_UI_URL: &str = "https://ui.perfetto.dev";
 
-pub fn start_server(port: u16) {
-    tokio::runtime::Runtime::new()
-        .unwrap()
-        .block_on(async_start_server(port));
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProfileFileFormat {
+    Firefox,
+    Perfetto,
 }
 
-async fn async_start_server(port: u16) {
-    use tower_http::cors::*;
+impl ProfileFileFormat {
+    pub fn from_path(path: &Path) -> Option<Self> {
+        match path.extension()?.to_str()?.to_ascii_lowercase().as_str() {
+            "json" => Some(Self::Firefox),
+            "pftrace" | "perfetto-trace" => Some(Self::Perfetto),
+            _ => None,
+        }
+    }
 
+    pub fn default_profile_name(self) -> &'static str {
+        match self {
+            Self::Firefox => "firefox-profiler.json",
+            Self::Perfetto => "profile.pftrace",
+        }
+    }
+
+    pub fn default_port(self) -> u16 {
+        match self {
+            Self::Firefox => 3000,
+            // Perfetto's official local trace helper uses this CSP-compatible port.
+            Self::Perfetto => 9001,
+        }
+    }
+
+    fn content_type(self) -> &'static str {
+        match self {
+            Self::Firefox => "application/json",
+            Self::Perfetto => "application/octet-stream",
+        }
+    }
+
+    fn cors_origin(self) -> &'static str {
+        match self {
+            Self::Firefox => FIREFOX_PROFILER_URL,
+            Self::Perfetto => PERFETTO_UI_URL,
+        }
+    }
+
+    fn file_name(self) -> &'static str {
+        match self {
+            Self::Firefox => "profile.json",
+            Self::Perfetto => "trace.pftrace",
+        }
+    }
+
+    fn viewer_name(self) -> &'static str {
+        match self {
+            Self::Firefox => "Firefox Profiler",
+            Self::Perfetto => "Perfetto UI",
+        }
+    }
+
+    fn viewer_url(self, profile_url: &str) -> String {
+        let profile_url = urlencoding::encode(profile_url);
+        match self {
+            Self::Firefox => format!("{FIREFOX_PROFILER_URL}/from-url/{profile_url}"),
+            Self::Perfetto => format!("{PERFETTO_UI_URL}/#!/?url={profile_url}"),
+        }
+    }
+}
+
+pub fn find_default_profile(dir: &Path) -> io::Result<PathBuf> {
+    let profiles = [ProfileFileFormat::Firefox, ProfileFileFormat::Perfetto]
+        .into_iter()
+        .map(|format| dir.join(format.default_profile_name()))
+        .filter(|path| path.is_file())
+        .collect::<Vec<_>>();
+
+    match profiles.as_slice() {
+        [profile] => Ok(profile.clone()),
+        [] => Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "no default profile found; use --profile",
+        )),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "multiple default profiles found; use --profile",
+        )),
+    }
+}
+
+pub fn start_profile_server(
+    port: u16,
+    profile_path: PathBuf,
+    format: ProfileFileFormat,
+) -> io::Result<()> {
+    tokio::runtime::Runtime::new()?.block_on(async_start_server(port, profile_path, format))
+}
+
+async fn async_start_server(
+    port: u16,
+    profile_path: PathBuf,
+    format: ProfileFileFormat,
+) -> io::Result<()> {
+    let token = Uuid::new_v4();
+    let profile_route = format!("/{token}/{}", format.file_name());
+    let profile_url = format!("http://127.0.0.1:{port}{profile_route}");
+    let viewer_url = format.viewer_url(&profile_url);
+    let index = format!(
+        "<a href='{viewer_url}'>Open profile in the {}</a>",
+        format.viewer_name()
+    );
+    let content_type = format
+        .content_type()
+        .parse()
+        .expect("profile content type is valid");
+    let profile = ServeFile::new_with_mime(profile_path, &content_type);
     let cors = CorsLayer::new()
-        .allow_origin(HeaderValue::from_static(FIREFOX_PROFILER_URL))
+        .allow_origin(HeaderValue::from_static(format.cors_origin()))
         .allow_methods([Method::GET]);
 
     let app = Router::new()
         .route(
             "/",
-            get(async || {
-                Html(format!(
-                    "<a href='{}/from-url/{}'>Open profile in the Firefox Profiler UI</a>",
-                    FIREFOX_PROFILER_URL,
-                    urlencoding::encode("http://localhost:3000/profile.json")
-                ))
+            get(move || {
+                let index = index.clone();
+                async move { Html(index) }
             }),
         )
-        .route(
-            "/profile.json",
-            get(async || {
-                let mut file = File::open("firefox-profiler.json").unwrap();
-                let mut ff_profile = Vec::new();
-                file.read_to_end(&mut ff_profile).unwrap();
-                let response = str::from_utf8(&ff_profile).unwrap().to_string();
-
-                Response::builder()
-                    .header(header::CONTENT_TYPE, "application/json")
-                    .body(Body::from(response))
-                    .unwrap()
-            }),
-        )
+        .route_service(&profile_route, profile)
         .layer(cors);
 
-    let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{}", port))
-        .await
-        .unwrap();
-    axum::serve(listener, app).await.unwrap();
+    let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{port}")).await?;
+    axum::serve(listener, app).await
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn infers_supported_profile_extensions() {
+        assert_eq!(
+            ProfileFileFormat::from_path(Path::new("profile.json")),
+            Some(ProfileFileFormat::Firefox)
+        );
+        assert_eq!(
+            ProfileFileFormat::from_path(Path::new("profile.pftrace")),
+            Some(ProfileFileFormat::Perfetto)
+        );
+        assert_eq!(ProfileFileFormat::from_path(Path::new("profile.pb")), None);
+    }
+
+    #[test]
+    fn finds_one_default_profile() {
+        let dir = tempdir().unwrap();
+        let profile = dir.path().join("profile.pftrace");
+        std::fs::write(&profile, []).unwrap();
+        assert_eq!(find_default_profile(dir.path()).unwrap(), profile);
+    }
+
+    #[test]
+    fn rejects_missing_or_ambiguous_default_profiles() {
+        let dir = tempdir().unwrap();
+        assert_eq!(
+            find_default_profile(dir.path()).unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
+
+        std::fs::write(dir.path().join("profile.pftrace"), []).unwrap();
+        std::fs::write(dir.path().join("firefox-profiler.json"), []).unwrap();
+        assert_eq!(
+            find_default_profile(dir.path()).unwrap_err().kind(),
+            io::ErrorKind::InvalidInput
+        );
+    }
+
+    #[test]
+    fn selects_content_type_from_format() {
+        assert_eq!(
+            ProfileFileFormat::Firefox.content_type(),
+            "application/json"
+        );
+        assert_eq!(
+            ProfileFileFormat::Perfetto.content_type(),
+            "application/octet-stream"
+        );
+    }
+
+    #[test]
+    fn builds_viewer_urls() {
+        let profile_url = "http://127.0.0.1:9001/token/trace.pftrace";
+        assert_eq!(
+            ProfileFileFormat::Perfetto.viewer_url(profile_url),
+            "https://ui.perfetto.dev/#!/?url=http%3A%2F%2F127.0.0.1%3A9001%2Ftoken%2Ftrace.pftrace"
+        );
+        assert_eq!(
+            ProfileFileFormat::Firefox.viewer_url(profile_url),
+            "https://profiler.firefox.com/from-url/http%3A%2F%2F127.0.0.1%3A9001%2Ftoken%2Ftrace.pftrace"
+        );
+    }
 }


### PR DESCRIPTION
Add Perfetto as a first-class CLI profile format for investigations where aggregated stacks lose temporal context. A dedicated collector preserves each sample's CLOCK_BOOTTIME timestamp, optionally symbolizes it locally, and writes interned StackSample packets without generated Perfetto protobuf bindings.

Generalize `lightswitch server` to open completed Firefox or Perfetto profiles in their native web viewers. It selects the sole default output automatically, rejects missing or ambiguous defaults, and still accepts explicit paths and format overrides. Tokenized CORS URLs and tower-http's ranged file serving make large traces practical while removing the direct tokio-util dependency.

Fixes: https://github.com/javierhonduco/lightswitch/issues/521