### PR TITLE
unwind: Handle large stack frames

### DIFF
--- a/src/bpf/profiler.bpf.c
+++ b/src/bpf/profiler.bpf.c
@@ -398,7 +398,7 @@ int dwarf_unwind(struct bpf_perf_event_data *ctx) {
         u64 found_pc = object_relative_pc_high + row->pc_low;
         u8 found_cfa_type = row->cfa_type;
         u8 found_rbp_type = row->rbp_type;
-        s16 found_cfa_offset = row->cfa_offset;
+        u16 found_cfa_offset = row->cfa_offset;
         s16 found_rbp_offset = row->rbp_offset;
         LOG("\tcfa type: %d, offset: %d (row pc: %llx)", found_cfa_type,
             found_cfa_offset, found_pc);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -153,6 +153,7 @@ fn test_integration() {
     let cpp_proc = TestProcess::new("main_cpp_clang_O1", false);
     let cpp_proc_new_pid_ns = TestProcess::new("main_cpp_clang_O2", true);
     let cpp_proc_fp = TestProcess::new("main_cpp_clang_no_omit_fp_O3", true);
+    let large_stack_frame_proc = TestProcess::new("large_stack_frame", false);
     let go_proc = TestProcess::new("main_go", false);
     let go_static_proc = TestProcess::new("main_go_static", false);
     let go_stripped_proc = TestProcess::new("main_go_stripped", false);
@@ -177,6 +178,7 @@ fn test_integration() {
     p.profile_pids(vec![cpp_proc.pid()]);
     p.profile_pids(vec![cpp_proc_new_pid_ns.pid()]);
     p.profile_pids(vec![cpp_proc_fp.pid()]);
+    p.profile_pids(vec![large_stack_frame_proc.pid()]);
     p.profile_pids(vec![go_proc.pid()]);
     p.profile_pids(vec![go_static_proc.pid()]);
     p.profile_pids(vec![go_stripped_proc.pid()]);
@@ -223,6 +225,18 @@ fn test_integration() {
         ],
         cpp_proc_fp.pid(),
     ));
+
+    let observed_stacks = stack_strings_for_pid(&symbolized_profile, large_stack_frame_proc.pid());
+    assert!(
+        assert_any_stack_contains(
+            &symbolized_profile,
+            &["large_stack_frame", "main"],
+            large_stack_frame_proc.pid(),
+        ),
+        "expected a stack containing large_stack_frame -> main, observed:\n{}",
+        observed_stacks.join("\n"),
+    );
+
     assert!(assert_any_stack_contains(
         &symbolized_profile,
         &[

--- a/tests/testprogs/shell.nix
+++ b/tests/testprogs/shell.nix
@@ -34,6 +34,7 @@ let
       clang -O3 -fomit-frame-pointer main.cpp -o main_cpp_clang_O3
 
       clang -O3 -fno-omit-frame-pointer main.cpp -o main_cpp_clang_no_omit_fp_O3
+      clang -O1 -fomit-frame-pointer -fasynchronous-unwind-tables large_stack_frame.cpp -o large_stack_frame
 
       ${if system == "aarch64-linux" then "clang -O3 -mbranch-protection=pac-ret main.cpp -o main_cpp_clang_pac" else ""}
     '';
@@ -49,6 +50,7 @@ let
       cp main_cpp_clang_O3 $out/bin
 
       cp main_cpp_clang_no_omit_fp_O3 $out/bin
+      cp large_stack_frame $out/bin
       ${if system == "aarch64-linux" then "cp main_cpp_clang_pac $out/bin" else ""}
     '';
     buildInputs = [

--- a/tests/testprogs/src/large_stack_frame.cpp
+++ b/tests/testprogs/src/large_stack_frame.cpp
@@ -1,0 +1,19 @@
+extern "C" __attribute__((noinline)) unsigned long large_stack_frame(unsigned long value) {
+  volatile unsigned char buffer[40000];
+
+  for (int i = 0; i < 40000; i++) {
+    buffer[i] = static_cast<unsigned char>(value + i);
+  }
+  for (int i = 0; i < 40000; i++) {
+    value += buffer[i];
+  }
+
+  return value;
+}
+
+int main() {
+  unsigned long value = 0;
+  while (true) {
+    value += large_stack_frame(value);
+  }
+}


### PR DESCRIPTION
Fix the signed -> unsigned silent conversion and add tests to catch these sort of issues in the future.

Fixes: https://github.com/javierhonduco/lightswitch/issues/522