### PR TITLE
Fix Go .text region calculation

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -861,6 +861,7 @@ impl Profiler {
         let object_files = self.object_files.read();
         let executable_info = object_files.get(&executable_id).unwrap();
         let executable_path = executable_info.path.clone();
+        let mut elf_loads = executable_info.elf_load_segments.clone();
         let opened_exe_path = if executable_info.is_vdso {
             executable_info.path.clone()
         } else {
@@ -891,8 +892,21 @@ impl Profiler {
                 }
 
                 // Go since pretty early on compiles with frame pointers by default.
-                unwind_info.push(CompactUnwindRow::frame_pointer(start_address, is_arm64));
-                unwind_info.push(CompactUnwindRow::stop_unwinding(end_address));
+                elf_loads.sort_by_key(|e| e.p_vaddr);
+                if let Some(code_elf_load) = elf_loads.first() {
+                    unwind_info.push(CompactUnwindRow::frame_pointer(
+                        code_elf_load.p_vaddr,
+                        is_arm64,
+                    ));
+                    unwind_info.push(CompactUnwindRow::stop_unwinding(
+                        code_elf_load.p_vaddr + code_elf_load.p_filesz,
+                    ));
+                } else {
+                    return Err(AddUnwindInformationError::Generic(
+                        "Go binary has no elf load segments".into(),
+                        "".into(),
+                    ));
+                }
 
                 unwind_info.sort_by_key(|e| e.pc);
                 Ok(unwind_info)


### PR DESCRIPTION
This was wrong, the mapping addresses were used to calculate the executable address and size but this should be read from the elf data.

Besides causing unwinding to fail this had another worse consequence that I saw on my machine with some workloads written in Go: as the address range differences would be very large, the number pages would be astronomically large, causing a very large memory spike and the BPF map to get full and never be cleaned up since the clean up logic would fail to remove these entries. The only fix would be to restart lightswitch.

This is a semi-temporary fix until proper Go unwinding data is read and used. This is a planned feature, but until then, let's remediate the very large allocation issue here.

Test Plan
=========

CI + before this PR, some custom logging reported this

```
- adding 1533713733 pages for "/nix/store/h9p4xw16i5x5ffdqs7k6h2q93j2ybbhr-moby-29.6.2/libexec/docker/dockerd"
```