### PR TITLE
Set User-Agent for the various HTTP clients

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -26,6 +26,7 @@ use crate::profile::{
 };
 use crate::profile::{raw_to_processed, RawSample};
 use crate::profile::{AggregatedProfile, RawAggregatedProfile, RawAggregatedSample};
+use crate::NAME_AND_VERSION;
 
 pub trait Collector {
     fn collect(
@@ -100,7 +101,9 @@ impl StreamingCollector {
         profile_frequency_hz: u64,
         metadata_provider: ThreadSafeGlobalMetadataProvider,
     ) -> Self {
-        let client_builder = reqwest::blocking::Client::builder().timeout(Duration::from_secs(30));
+        let client_builder = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .user_agent(NAME_AND_VERSION);
         let client = client_builder
             .build()
             .expect("build lightswitch HTTP client");
@@ -197,7 +200,9 @@ impl PyroscopeCollector {
         node_name: String,
     ) -> Self {
         let push_url = format!("{}/push.v1.PusherService/Push", server_url);
-        let client_builder = reqwest::blocking::Client::builder().timeout(Duration::from_secs(30));
+        let client_builder = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .user_agent(NAME_AND_VERSION);
         let client = client_builder.build().expect("build pyroscope HTTP client");
         Self {
             local_symbolizer,

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -10,6 +10,8 @@ use tracing::instrument;
 
 use lightswitch_object::BuildId;
 
+use crate::NAME_AND_VERSION;
+
 /// Handles with debug information.
 ///
 /// This currently experimental, not feature-complete and not used yet during
@@ -104,9 +106,11 @@ impl DebugInfoBackendRemote {
             server_url,
             query_client: reqwest::blocking::Client::builder()
                 .timeout(query_timeout)
+                .user_agent(NAME_AND_VERSION)
                 .build()?,
             upload_client: reqwest::blocking::Client::builder()
                 .timeout(upload_timeout)
+                .user_agent(NAME_AND_VERSION)
                 .build()?,
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,5 @@ pub mod profiler;
 pub mod server;
 pub mod usym;
 pub mod util;
+
+pub(crate) const NAME_AND_VERSION: &str = concat!("lightswitch v", env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
This can help identify the source of the data being request or written by lightswitch. Having the version can also be helpful to spot differences in behaviour in new releases.

Test Plan
=========

CI