### PR TITLE
Surface unwind diagnostics in profiles

### DIFF
--- a/src/aggregator.rs
+++ b/src/aggregator.rs
@@ -18,10 +18,9 @@ impl Aggregator {
         for sample in raw_samples {
             if sample.ustack.is_empty() && sample.kstack.is_empty() {
                 debug!(
-                    "No stack present in provided sample={}, skipping...",
-                    sample
+                    "No stack present in provided sample for process {} with result {:?}",
+                    sample.pid, sample.result
                 );
-                continue;
             }
 
             let mut hasher = DefaultHasher::new();
@@ -41,12 +40,14 @@ impl Aggregator {
 mod tests {
     use crate::aggregator::Aggregator;
     use crate::profile::RawSample;
+    use crate::profile::SampleResult;
 
     #[test]
     fn test_aggregate_raw_samples() {
         let raw_sample_1 = RawSample {
             pid: 1234,
             tid: 1235,
+            result: SampleResult::Started,
             collected_at: 1748865070,
             ustack: vec![0xffff, 0xffff],
             kstack: vec![0xffff, 0xdddd, 0xaaaa, 0xeeee, 0xaaae],
@@ -55,6 +56,7 @@ mod tests {
         let raw_sample_2 = RawSample {
             pid: 1234,
             tid: 1235,
+            result: SampleResult::Started,
             collected_at: 1748865070,
             ustack: vec![0xdddd, 0xfeedbee, 0xddddef, 0xbeefdad],
             kstack: vec![],
@@ -90,6 +92,7 @@ mod tests {
         let raw_sample_1 = RawSample {
             pid: 1234,
             tid: 1235,
+            result: SampleResult::Started,
             collected_at: 1748865070,
             ustack: vec![0xffff, 0xdeadbeef],
             kstack: vec![0xffff, 0xdddd, 0xaaaa, 0xeeee, 0xaaae],
@@ -98,6 +101,7 @@ mod tests {
         let raw_sample_2 = RawSample {
             pid: 1234,
             tid: 1235,
+            result: SampleResult::Started,
             collected_at: 1748865070,
             ustack: raw_sample_1.ustack.clone(),
             kstack: vec![],
@@ -130,6 +134,7 @@ mod tests {
         let raw_sample_1 = RawSample {
             pid: 1234,
             tid: 1235,
+            result: SampleResult::Started,
             collected_at: 1748865070,
             ustack: vec![0xffff, 0xdeadbeef],
             kstack: vec![0xffff, 0xdddd, 0xaaaa, 0xeeee, 0xaaae],
@@ -138,6 +143,7 @@ mod tests {
         let raw_sample_2 = RawSample {
             pid: 1234,
             tid: 1235,
+            result: SampleResult::Started,
             collected_at: 1748865070,
             ustack: vec![0xdddd, 0xfeedbee, 0xddddef, 0xbeefdad],
             kstack: raw_sample_1.kstack.clone(),
@@ -175,6 +181,7 @@ mod tests {
         let raw_sample_1 = RawSample {
             pid: 1234,
             tid: 1235,
+            result: SampleResult::Started,
             collected_at: 1748865070,
             ustack: ustack.clone(),
             kstack: kstack.clone(),
@@ -183,6 +190,7 @@ mod tests {
         let raw_sample_2 = RawSample {
             pid: 1234,
             tid: 1236,
+            result: SampleResult::Started,
             collected_at: 1748865070,
             ustack: ustack.clone(),
             kstack: kstack.clone(),
@@ -191,6 +199,7 @@ mod tests {
         let raw_sample_3 = RawSample {
             pid: 123,
             tid: 124,
+            result: SampleResult::Started,
             collected_at: 1748865070,
             ustack: ustack.clone(),
             kstack: kstack.clone(),

--- a/src/bpf/profiler.bpf.c
+++ b/src/bpf/profiler.bpf.c
@@ -246,7 +246,35 @@ static __always_inline bool retrieve_task_registers(u64 *ip, u64 *sp, u64 *bp, u
     return true;
 }
 
-static __always_inline void add_stack(struct bpf_perf_event_data *ctx,
+void send_sample_impl(struct bpf_perf_event_data *ctx, sample_t *sample) {
+    u32 sample_size = sizeof(sample_t)
+                      // Remove the actual stack buffer which was doubled to appease the verifier.
+                      - 2 * MAX_STACK_DEPTH * sizeof(u64)
+                      // Add the actual stack size in bytes.
+                      + (sample->stack.ulen + sample->stack.klen) * sizeof(u64);
+
+    // Appease the verifier.
+    if (sample_size > sizeof(sample_t)) {
+        return;
+    }
+
+    int ret = 0;
+    if (lightswitch_config.use_ring_buffers) {
+        ret = bpf_ringbuf_output(&stacks_rb, sample, sample_size, 0);
+    } else {
+        ret = bpf_perf_event_output(ctx, &stacks, BPF_F_CURRENT_CPU, sample, sample_size);
+    }
+
+    if (ret < 0) {
+        bpf_printk(
+            "send_sample_impl failed ret=%d, use_ring_buffers=%d",
+            ret,
+            lightswitch_config.use_ring_buffers);
+        bump_unwind_error_failure_sending_stack();
+    }
+}
+
+static __always_inline void send_sample(struct bpf_perf_event_data *ctx,
                                       unwind_state_t *unwind_state) {
     // Unwind and copy kernel stack.
     u32 ulen = unwind_state->sample.stack.ulen;
@@ -266,31 +294,7 @@ static __always_inline void add_stack(struct bpf_perf_event_data *ctx,
     unwind_state->sample.tid = per_thread_id;
     unwind_state->sample.collected_at = bpf_ktime_get_boot_ns();
 
-    u32 sample_size = sizeof(sample_t)
-                      // Remove the actual stack buffer which was doubled to appease the verifier.
-                      - 2 * MAX_STACK_DEPTH * sizeof(u64)
-                      // Add the actual stack size in bytes.
-                      + (unwind_state->sample.stack.ulen + unwind_state->sample.stack.klen) * sizeof(u64);
-
-    // Appease the verifier.
-    if (sample_size > sizeof(sample_t)) {
-        return;
-    }
-
-    int ret = 0;
-    if (lightswitch_config.use_ring_buffers) {
-        ret = bpf_ringbuf_output(&stacks_rb, &(unwind_state->sample), sample_size, 0);
-    } else {
-        ret = bpf_perf_event_output(ctx, &stacks, BPF_F_CURRENT_CPU, &(unwind_state->sample), sample_size);
-    }
-
-    if (ret < 0) {
-        bpf_printk(
-            "add_stack failed ret=%d, use_ring_buffers=%d",
-            ret,
-            lightswitch_config.use_ring_buffers);
-        bump_unwind_error_failure_sending_stack();
-    }
+    send_sample_impl(ctx, &(unwind_state->sample));
 }
 
 // The unwinding machinery lives here.
@@ -300,9 +304,7 @@ int dwarf_unwind(struct bpf_perf_event_data *ctx) {
     unsigned int level = lightswitch_config.userspace_pid_ns_level;
     int per_process_id = BPF_CORE_READ(task, group_leader, thread_pid, numbers[level].nr);
 
-    bool reached_bottom_of_stack = false;
     u64 zero = 0;
-
     unwind_state_t *unwind_state = bpf_map_lookup_elem(&heap, &zero);
     if (unwind_state == NULL) {
         LOG("unwind_state is NULL, should not happen");
@@ -321,19 +323,22 @@ int dwarf_unwind(struct bpf_perf_event_data *ctx) {
         if (mapping == NULL) {
             LOG("[error] no mapping found for pc %llx", unwind_state->ip);
             bump_unwind_error_mapping_not_found();
-            return 1;
+            unwind_state->sample.result = SAMPLE_MAPPING_NOT_FOUND;
+            break;
         }
 
         if (unwind_state->ip < mapping->begin || unwind_state->ip >= mapping->end) {
             LOG("[error] pc %llx not contained within begin: %llx end: %llx", unwind_state->ip, mapping->begin, mapping->end);
             bump_unwind_error_mapping_does_not_contain_pc();
-            return 1;
+            unwind_state->sample.result = SAMPLE_MAPPING_DOES_NOT_CONTAIN_PC;
+            break;
         }
 
         if (mapping->type == MAPPING_TYPE_ANON) {
             LOG("JIT section, stopping");
             bump_unwind_jit_encountered();
-            return 1;
+            unwind_state->sample.result = SAMPLE_MAPPING_JIT;
+            break;
         }
 
         if (mapping->type == MAPPING_TYPE_VDSO) {
@@ -359,7 +364,8 @@ int dwarf_unwind(struct bpf_perf_event_data *ctx) {
                 .address = unwind_state->ip & PAGE_MASK,
             };
             send_event(&event, ctx);
-            return 1;
+            unwind_state->sample.result = SAMPLE_MAPPING_MISSING_UNWIND_INFO;
+            break;
         }
 
         u64 table_idx = find_offset_for_pc(inner, object_relative_pc_low, low_index, high_index);
@@ -405,24 +411,26 @@ int dwarf_unwind(struct bpf_perf_event_data *ctx) {
 
         if (found_cfa_type == CFA_TYPE_OFFSET_DID_NOT_FIT) {
             bump_unwind_error_cfa_offset_did_not_fit();
-            return 1;
+            unwind_state->sample.result = SAMPLE_UNSUPPORTED_UNWIND_RULE;
+            break;
         }
 
         if (found_cfa_type == CFA_TYPE_END_OF_FDE_MARKER) {
             LOG("[info] pc %llx not contained in the unwind info, found marker",
                 unwind_state->ip);
-            reached_bottom_of_stack = true;
+            unwind_state->sample.result = SAMPLE_SUCCESS;
             break;
         }
 
         if (found_rbp_type == RBP_TYPE_OFFSET_DID_NOT_FIT) {
             bump_unwind_error_rbp_offset_did_not_fit();
-            return 1;
+            unwind_state->sample.result = SAMPLE_UNSUPPORTED_UNWIND_RULE;
+            break;
         }
 
         if (found_rbp_type == RBP_TYPE_UNDEFINED_RETURN_ADDRESS) {
             LOG("[info] null return address, end of stack", unwind_state->ip);
-            reached_bottom_of_stack = true;
+            unwind_state->sample.result = SAMPLE_SUCCESS;
             break;
         }
 
@@ -439,7 +447,8 @@ int dwarf_unwind(struct bpf_perf_event_data *ctx) {
             LOG("\t[error] frame pointer is %d (register or exp), bailing out",
                 found_rbp_type);
             bump_unwind_error_unsupported_frame_pointer_action();
-            return 1;
+            unwind_state->sample.result = SAMPLE_UNSUPPORTED_UNWIND_RULE;;
+            break;
         }
 
         u64 previous_rsp = 0;
@@ -456,6 +465,8 @@ int dwarf_unwind(struct bpf_perf_event_data *ctx) {
             if (ret < 0) {
                 LOG("[error] reading previous rsp failed with %d", ret);
                 bump_unwind_error_previous_rsp_read();
+                unwind_state->sample.result = ret == -EFAULT ? SAMPLE_MEM_READ_FAULT_ERROR : SAMPLE_MEM_READ_GENERIC_ERROR;
+                break;
             }
             previous_rsp += addition;
         } else if (found_cfa_type == CFA_TYPE_CFA_TYPE_UNSUP_EXP) {
@@ -474,7 +485,8 @@ int dwarf_unwind(struct bpf_perf_event_data *ctx) {
         } else {
             LOG("\t[unsup] cfa type %d not valid at ip: %llx", found_cfa_type, object_relative_pc);
             bump_unwind_error_unsupported_cfa_register();
-            return 1;
+            unwind_state->sample.result = SAMPLE_UNSUPPORTED_UNWIND_RULE;
+            break;
         }
 
         // TODO(javierhonduco): A possible check could be to see whether this value
@@ -500,7 +512,8 @@ int dwarf_unwind(struct bpf_perf_event_data *ctx) {
             if (ret < 0) {
                 LOG("[error] previous_rbp read failed with %d", ret);
                 bump_unwind_error_previous_rbp_read();
-                return 1;
+                unwind_state->sample.result = ret == -EFAULT ? SAMPLE_MEM_READ_FAULT_ERROR : SAMPLE_MEM_READ_GENERIC_ERROR;
+                break;
             }
         }
 
@@ -539,7 +552,8 @@ int dwarf_unwind(struct bpf_perf_event_data *ctx) {
             LOG("[error] previous_rip read failed, ret=%d @ %llx",
                 err, previous_rip_addr);
             bump_unwind_error_previous_rip_read();
-            return 1;
+            unwind_state->sample.result = err == -EFAULT ? SAMPLE_MEM_READ_FAULT_ERROR : SAMPLE_MEM_READ_GENERIC_ERROR;
+            break;
         }
 
         if (previous_rip == 0) {
@@ -560,7 +574,30 @@ int dwarf_unwind(struct bpf_perf_event_data *ctx) {
         // Frame finished! :)
     }
 
-    if (reached_bottom_of_stack) {
+    // Continue unwinding the stack if we have enough tail call budget and space
+    // in our stack storage.
+    if (unwind_state->sample.result == SAMPLE_STARTED) {
+        if (unwind_state->sample.stack.ulen < MAX_STACK_DEPTH &&
+                   unwind_state->tail_calls < MAX_TAIL_CALLS)
+        {
+            LOG("Continuing walking the stack in a tail call, current tail %d",
+                unwind_state->tail_calls);
+            unwind_state->tail_calls++;
+            bpf_tail_call(ctx, &programs, PROGRAM_NATIVE_UNWINDER);
+            // While `bpf_tail_call` won't typically fail, it can if the tail call limit
+            // is exceeded etc or the programs map is not correctly populated. Setting the
+            // state to truncated to surface this error.
+            unwind_state->sample.result = SAMPLE_TRUNCATED;
+        } else {
+            // We couldn't get the whole stacktrace.
+            bump_unwind_error_truncated();
+            unwind_state->sample.result = SAMPLE_TRUNCATED;
+        }
+    }
+
+    if (unwind_state->sample.result == SAMPLE_SUCCESS) {
+        LOG("======= reached bottom frame! =======");
+        bump_unwind_success_dwarf();
 #ifdef __TARGET_ARCH_x86
         // We've reached the bottom of the stack once we don't find an unwind
         // entry for the given program counter and the current frame pointer
@@ -581,22 +618,11 @@ int dwarf_unwind(struct bpf_perf_event_data *ctx) {
             bump_unwind_bp_non_zero_for_bottom_frame();
         }
 #endif
-        LOG("======= reached bottom frame! =======");
-        add_stack(ctx, unwind_state);
-        bump_unwind_success_dwarf();
-        return 0;
-
-    } else if (unwind_state->sample.stack.ulen < MAX_STACK_DEPTH &&
-               unwind_state->tail_calls < MAX_TAIL_CALLS) {
-        LOG("Continuing walking the stack in a tail call, current tail %d",
-            unwind_state->tail_calls);
-        unwind_state->tail_calls++;
-        bpf_tail_call(ctx, &programs, PROGRAM_NATIVE_UNWINDER);
     }
 
-    // We couldn't get the whole stacktrace.
-    LOG("Truncated stack, won't be sent");
-    bump_unwind_error_truncated();
+    // Either way send the sample, the `result` field will be set to success
+    // or an error type if any, which can be surfaced to end users.
+    send_sample(ctx, unwind_state);
     return 0;
 }
 
@@ -608,6 +634,7 @@ static __always_inline bool set_initial_state(unwind_state_t *unwind_state, bpf_
 
     unwind_state->sample.pid = 0;
     unwind_state->sample.tid = 0;
+    unwind_state->sample.result = SAMPLE_STARTED;
     unwind_state->sample.collected_at = 0;
 
     if (in_kernel(PT_REGS_IP(regs))) {
@@ -653,7 +680,6 @@ int on_event(struct bpf_perf_event_data *ctx) {
             return 0;
         }
         set_initial_state(profiler_state, &ctx->regs);
-
         bpf_tail_call(ctx, &programs, PROGRAM_NATIVE_UNWINDER);
         return 0;
     }

--- a/src/bpf/profiler.h
+++ b/src/bpf/profiler.h
@@ -167,9 +167,26 @@ typedef struct {
     u64 addresses[MAX_STACK_DEPTH * 2];
 } native_stack_t;
 
+enum sample_result {
+    SAMPLE_STARTED = 0,
+    SAMPLE_SUCCESS = 1,
+    SAMPLE_TRUNCATED = 2,
+    SAMPLE_WAITING_FOR_USERSPACE = 3,
+    SAMPLE_RATE_LIMITED = 4,
+    SAMPLE_UNWINDING_ERROR = 5,
+    SAMPLE_MAPPING_NOT_FOUND = 6,
+    SAMPLE_MAPPING_DOES_NOT_CONTAIN_PC = 7,
+    SAMPLE_MAPPING_JIT = 8,
+    SAMPLE_MAPPING_MISSING_UNWIND_INFO = 9,
+    SAMPLE_MEM_READ_FAULT_ERROR = 10,
+    SAMPLE_MEM_READ_GENERIC_ERROR = 11,
+    SAMPLE_UNSUPPORTED_UNWIND_RULE = 12,
+};
+
 typedef struct {
     int pid;
     int tid;
+    enum sample_result result;
     u64 collected_at;
     native_stack_t stack;
 } sample_t;

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -739,10 +739,8 @@ impl Collector for FirefoxProfilerCollector {
                     tid: sample.tid,
                 });
 
-            let process_name = &self
-                .pid_to_comm
-                .get(&sample.pid)
-                .expect("process to have a name");
+            let default_name = "process to have a name".to_string();
+            let process_name = &self.pid_to_comm.get(&sample.pid).unwrap_or(&default_name);
             let thread_name = match &meta.iter().find(|e| e.key == "thread.name").unwrap().value {
                 MetadataLabelValue::String(a) => a,
                 MetadataLabelValue::Number(_, _) => todo!(),
@@ -794,7 +792,7 @@ impl Collector for FirefoxProfilerCollector {
                                 .unwrap()
                                 .as_ref()
                                 .unwrap_or(&SymbolizedFrame {
-                                    name: "not found".to_string(),
+                                    name: format!("error/generic: {:?}", e.symbolization_result),
                                     inlined: false,
                                     filename: None,
                                     line: None,

--- a/src/profile/convert.rs
+++ b/src/profile/convert.rs
@@ -19,7 +19,8 @@ use crate::ksym::KsymIter;
 use crate::process::ObjectFileInfo;
 use crate::process::ProcessInfo;
 use crate::profile::{
-    AggregatedProfile, AggregatedSample, Frame, FrameAddress, RawAggregatedProfile, SymbolizedFrame,
+    AggregatedProfile, AggregatedSample, Frame, FrameAddress, RawAggregatedProfile, SampleResult,
+    SymbolizedFrame,
 };
 use crate::usym::symbolize_native_stack_blaze;
 use lightswitch_object::ExecutableId;
@@ -190,6 +191,14 @@ pub fn to_pprof(
             }
         }
 
+        if sample.result != SampleResult::Success {
+            let mapping_id = pprof.add_mapping(0x0, 0x0, 0x0, "lightswitch-unwinder-errors", "");
+            let (line, _) =
+                pprof.add_line(&format!("error/unwinder: {:?}", sample.result), None, None);
+            let location = pprof.add_location(0x0, mapping_id, vec![line]);
+            location_ids.push(location);
+        }
+
         let task_key = TaskKey {
             tid: sample.tid,
             pid: sample.pid,
@@ -236,13 +245,18 @@ pub fn fold_profile(
     let mut folded = String::new();
 
     for sample in profile {
-        let ustack = sample
+        let mut ustack = sample
             .ustack
             .clone()
             .into_iter()
             .rev()
             .map(|e| e.format_all_info(only_show_function_names))
             .collect::<Vec<String>>();
+
+        if sample.result != SampleResult::Success {
+            ustack.push(format!("error/unwinder: {:?}", sample.result));
+        }
+
         let ustack = ustack.join(";");
         let kstack = sample
             .kstack
@@ -318,19 +332,29 @@ pub fn symbolize_profile(
     let ksyms = KsymIter::from_kallsyms()
         .sorted_by(|a, b| a.start_addr.cmp(&b.start_addr))
         .collect::<Vec<_>>();
+    use crate::profile::SampleResult;
 
     for sample in profile {
+        let mut ustack = symbolize_user_stack(
+            &addresses_per_sample,
+            procs,
+            objs,
+            sample.pid,
+            &sample.ustack,
+        );
+
+        if sample.result != SampleResult::Success {
+            ustack.push(Frame::with_error(
+                0x0,
+                format!("sample failed with `{:?}`", sample.result),
+            ));
+        }
         let symbolized_sample = AggregatedSample {
             pid: sample.pid,
             tid: sample.tid,
+            result: sample.result,
             count: sample.count,
-            ustack: symbolize_user_stack(
-                &addresses_per_sample,
-                procs,
-                objs,
-                sample.pid,
-                &sample.ustack,
-            ),
+            ustack,
             kstack: symbolize_kernel_stack(&sample.kstack, &ksyms),
         };
         r.push(symbolized_sample);
@@ -348,9 +372,6 @@ pub fn fetch_symbols_for_profile(
         HashMap::new();
 
     for sample in profile {
-        if sample.ustack.is_empty() {
-            continue;
-        }
         let Some(info) = procs.get(&sample.pid) else {
             continue;
         };
@@ -442,7 +463,7 @@ fn symbolize_user_stack(
     pid: i32,
     native_stack: &[Frame],
 ) -> Vec<Frame> {
-    let mut result = Vec::new();
+    let mut result = Vec::with_capacity(native_stack.len());
 
     for frame in native_stack.iter() {
         let Some(info) = procs.get(&pid) else {

--- a/src/profile/perfetto.rs
+++ b/src/profile/perfetto.rs
@@ -310,7 +310,7 @@ pub fn write_perfetto<W: Write>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::profile::{SymbolizationError, SymbolizedFrame};
+    use crate::profile::{SampleResult, SymbolizationError, SymbolizedFrame};
 
     #[derive(Debug)]
     enum Value<'a> {
@@ -391,6 +391,7 @@ mod tests {
                 sample: AggregatedSample {
                     pid: 42,
                     tid: 43,
+                    result: SampleResult::Success,
                     ustack: vec![
                         frame(3, "leaf", Some("sample.rs"), Some(30)),
                         frame(2, "caller", Some("sample.rs"), Some(20)),
@@ -405,6 +406,7 @@ mod tests {
                 sample: AggregatedSample {
                     pid: 42,
                     tid: 43,
+                    result: SampleResult::Success,
                     ustack: vec![frame(3, "leaf", Some("sample.rs"), Some(30))],
                     kstack: vec![],
                     count: 1,
@@ -458,6 +460,7 @@ mod tests {
             sample: AggregatedSample {
                 pid: 1,
                 tid: 1,
+                result: SampleResult::Success,
                 ustack: vec![
                     Frame {
                         virtual_address: 0x123,

--- a/src/profile/sample.rs
+++ b/src/profile/sample.rs
@@ -6,17 +6,67 @@ use anyhow::anyhow;
 use lightswitch_object::ExecutableId;
 use tracing::error;
 
+use crate::bpf::profiler_bindings::sample_result;
 use crate::kernel::KERNEL_PID;
 use crate::process::ObjectFileInfo;
 use crate::process::Pid;
 use crate::process::ProcessInfo;
 use crate::profile::Frame;
 
-/// This *must* be in sync with the C struct `sample_t`.
+#[derive(Default, Debug, Eq, Clone, Copy, PartialEq, Hash)]
+pub enum SampleResult {
+    #[default]
+    Started,
+    Success,
+    Truncated,
+    WaitingForUserspace,
+    RateLimited,
+    UnwindingError,
+    MappingNotFound,
+    MappingDoesNotContainPC,
+    MappingJIT,
+    MappingMissingUnwindInfo,
+    MemReadFaultError,
+    MemReadGenericError,
+    UnsupportedUnwindRule,
+}
+
+impl From<sample_result> for SampleResult {
+    #[allow(non_upper_case_globals)]
+    #[allow(non_snake_case)]
+    fn from(sample: sample_result) -> Self {
+        use crate::bpf::profiler_bindings::*;
+
+        match sample {
+            sample_result_SAMPLE_STARTED => SampleResult::Started,
+            sample_result_SAMPLE_SUCCESS => SampleResult::Success,
+            sample_result_SAMPLE_TRUNCATED => SampleResult::Truncated,
+            sample_result_SAMPLE_WAITING_FOR_USERSPACE => SampleResult::WaitingForUserspace,
+            sample_result_SAMPLE_RATE_LIMITED => SampleResult::RateLimited,
+            sample_result_SAMPLE_UNWINDING_ERROR => SampleResult::UnwindingError,
+            sample_result_SAMPLE_MAPPING_NOT_FOUND => SampleResult::MappingNotFound,
+            sample_result_SAMPLE_MAPPING_DOES_NOT_CONTAIN_PC => {
+                SampleResult::MappingDoesNotContainPC
+            }
+            sample_result_SAMPLE_MAPPING_JIT => SampleResult::MappingJIT,
+            sample_result_SAMPLE_MAPPING_MISSING_UNWIND_INFO => {
+                SampleResult::MappingMissingUnwindInfo
+            }
+            sample_result_SAMPLE_MEM_READ_FAULT_ERROR => SampleResult::MemReadFaultError,
+            sample_result_SAMPLE_MEM_READ_GENERIC_ERROR => SampleResult::MemReadGenericError,
+            sample_result_SAMPLE_UNSUPPORTED_UNWIND_RULE => SampleResult::UnsupportedUnwindRule,
+            _ => {
+                todo!("sample result type {sample} not valid")
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct RawSample {
     pub pid: Pid,
     pub tid: Pid,
+    pub result: SampleResult,
     pub collected_at: u64,
     pub ustack: Vec<u64>,
     pub kstack: Vec<u64>,
@@ -35,36 +85,46 @@ pub enum RawSampleParsingError {
 /// The unwound stack trace, [`crate::bpf::profiler_bindings::native_stack_t`],
 /// is stored in the last field of [`crate::bpf::profiler_bindings::sample_t`]
 /// and only the useful data is sent to userspace. This means that every sample
-/// might have a different number of frames. This is similar to C99's "Flexible
+/// might have variable number of frames. This is similar to C99's "Flexible
 /// Array Fields" and it is the reason why we need to manually parse it
 /// as `plain` doesn't correctly know how to deal with this.
+///
+/// This decoding logic *must* be in sync with the C struct `sample_t`.
 impl RawSample {
     pub fn from_bytes(data: &[u8]) -> Result<Self, RawSampleParsingError> {
+        const FIELD_SIZE_BEFORE_STACK: usize = 32;
+        const MAX_STACK_SIZE: usize = 200 * 2 * 8;
+
         let sample_len = data.len();
-        if sample_len < 24 {
+        if sample_len < FIELD_SIZE_BEFORE_STACK {
             return Err(RawSampleParsingError::BeforeStackTooSmall);
         }
-        if sample_len > 24 + 200 * 2 * 8 {
+        if sample_len > FIELD_SIZE_BEFORE_STACK + MAX_STACK_SIZE {
             return Err(RawSampleParsingError::SampleTooLarge);
         }
 
         let pid = i32::from_ne_bytes(data[0..4].try_into().unwrap());
         let tid = i32::from_ne_bytes(data[4..8].try_into().unwrap());
-        let collected_at = u64::from_ne_bytes(data[8..16].try_into().unwrap());
-        let ulen = u32::from_ne_bytes(data[16..20].try_into().unwrap()) as usize;
-        let klen = u32::from_ne_bytes(data[20..24].try_into().unwrap()) as usize;
+        let result = u64::from_ne_bytes(data[8..16].try_into().unwrap()) as u32;
+        let collected_at = u64::from_ne_bytes(data[16..24].try_into().unwrap());
+        let ulen = u32::from_ne_bytes(data[24..28].try_into().unwrap()) as usize;
+        let klen = u32::from_ne_bytes(data[28..32].try_into().unwrap()) as usize;
 
-        if sample_len < 24 + (ulen + klen) * 8 {
+        let user_stack_size = ulen * 8;
+        let combined_stack_size = (ulen + klen) * 8;
+
+        if sample_len < FIELD_SIZE_BEFORE_STACK + combined_stack_size {
             return Err(RawSampleParsingError::StackTooSmall);
         }
 
-        let ustack = data[24..(24 + ulen * 8)]
+        let ustack = data[FIELD_SIZE_BEFORE_STACK..(FIELD_SIZE_BEFORE_STACK + user_stack_size)]
             .as_chunks::<8>()
             .0
             .iter()
             .map(|chunk| u64::from_ne_bytes(*chunk))
             .collect::<Vec<_>>();
-        let kstack = data[(24 + ulen * 8)..(24 + ulen * 8 + klen * 8)]
+        let kstack = data
+            [(FIELD_SIZE_BEFORE_STACK + ulen * 8)..(FIELD_SIZE_BEFORE_STACK + combined_stack_size)]
             .as_chunks::<8>()
             .0
             .iter()
@@ -74,6 +134,7 @@ impl RawSample {
         Ok(RawSample {
             pid,
             tid,
+            result: result.into(),
             collected_at,
             ustack,
             kstack,
@@ -83,12 +144,22 @@ impl RawSample {
 
 impl std::hash::Hash for RawSample {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.pid.hash(state);
-        self.kstack.hash(state);
-        // The collected_at field is excluded when hashing
-        // the samples for aggregation.
-        self.tid.hash(state);
-        self.ustack.hash(state);
+        let RawSample {
+            pid,
+            tid,
+            result,
+            // The collected_at field is excluded when hashing
+            // the samples for aggregation.
+            collected_at: _,
+            ustack,
+            kstack,
+        } = self;
+
+        pid.hash(state);
+        tid.hash(state);
+        result.hash(state);
+        ustack.hash(state);
+        kstack.hash(state);
     }
 }
 
@@ -132,6 +203,7 @@ impl RawAggregatedSample {
         let mut processed_sample = AggregatedSample {
             pid: self.sample.pid,
             tid: self.sample.tid,
+            result: self.sample.result,
             ustack: Vec::new(),
             kstack: Vec::new(),
             count: self.count,
@@ -143,6 +215,7 @@ impl RawAggregatedSample {
 
         for virtual_address in &self.sample.ustack {
             let Some(mapping) = info.mappings.for_address(virtual_address) else {
+                // TODO: add a frame here for diagnostics
                 continue;
             };
 
@@ -214,6 +287,7 @@ pub struct FrameAddress {
 pub struct AggregatedSample {
     pub pid: Pid,
     pub tid: Pid,
+    pub result: SampleResult,
     pub ustack: Vec<Frame>,
     pub kstack: Vec<Frame>,
     pub count: u64,
@@ -237,6 +311,7 @@ impl fmt::Display for AggregatedSample {
         fmt.debug_struct("AggregatedSample")
             .field("pid", &self.pid)
             .field("tid", &self.tid)
+            .field("result", &self.result)
             .field("ustack", &format_symbolized_stack(&self.ustack))
             .field("kstack", &format_symbolized_stack(&self.kstack))
             .field("count", &self.count)
@@ -267,6 +342,7 @@ mod tests {
         let c_sample = sample_t {
             pid: 234,
             tid: 987,
+            result: 0,
             collected_at: 0xDEADBEEF,
             stack: native_stack_t {
                 ulen: 2,
@@ -275,7 +351,7 @@ mod tests {
             },
         };
         assert_eq!(
-            RawSample::from_bytes(&unsafe { plain::as_bytes(&c_sample) }[..30]),
+            RawSample::from_bytes(&unsafe { plain::as_bytes(&c_sample) }[..38]),
             Err(RawSampleParsingError::StackTooSmall)
         );
     }
@@ -285,6 +361,7 @@ mod tests {
         let c_sample = sample_t {
             pid: 234,
             tid: 987,
+            result: 0,
             collected_at: 0xDEADBEEF,
             stack: native_stack_t {
                 ulen: 2,
@@ -307,6 +384,7 @@ mod tests {
         let mut c_sample = sample_t {
             pid: 234,
             tid: 987,
+            result: 0,
             collected_at: 0xDEADBEEF,
             stack: native_stack_t {
                 ulen: 2,
@@ -326,6 +404,7 @@ mod tests {
             Ok(RawSample {
                 pid: 234,
                 tid: 987,
+                result: SampleResult::Started,
                 collected_at: 0xDEADBEEF,
                 ustack: vec![0xFFFBBBDDD, 0x113355770],
                 kstack: vec![0xBBBAAADDD]
@@ -340,6 +419,7 @@ mod tests {
             sample: RawSample {
                 pid: 1234,
                 tid: 1235,
+                result: SampleResult::Started,
                 collected_at: 1748865070,
                 ustack: vec![0xffff, 0xdeadbeef],
                 kstack: vec![],
@@ -353,6 +433,7 @@ mod tests {
             sample: RawSample {
                 pid: 1234,
                 tid: 1235,
+                result: SampleResult::Started,
                 collected_at: 1748865170,
                 ustack: vec![],
                 kstack: vec![],
@@ -394,21 +475,23 @@ mod tests {
         let sample = AggregatedSample {
             pid: 1234567,
             tid: 1234568,
+            result: SampleResult::Started,
             ustack: ustack_data,
             kstack: kstack_data.clone(),
             count: 128,
         };
-        insta::assert_snapshot!(format!("{}", sample), @r#"AggregatedSample { pid: 1234567, tid: 1234568, ustack: "[  0: ufunc3,  1: ufunc2,  2: ufunc1]", kstack: "[  0: kfunc2,  1: kfunc1]", count: 128 }"#);
+        insta::assert_snapshot!(format!("{}", sample), @r#"AggregatedSample { pid: 1234567, tid: 1234568, result: Started, ustack: "[  0: ufunc3,  1: ufunc2,  2: ufunc1]", kstack: "[  0: kfunc2,  1: kfunc1]", count: 128 }"#);
 
         let ustack_data = vec![];
 
         let sample = AggregatedSample {
             pid: 98765,
             tid: 98766,
+            result: SampleResult::Started,
             ustack: ustack_data,
             kstack: kstack_data.clone(),
             count: 1001,
         };
-        insta::assert_snapshot!(format!("{}", sample), @r#"AggregatedSample { pid: 98765, tid: 98766, ustack: "[NONE]", kstack: "[  0: kfunc2,  1: kfunc1]", count: 1001 }"#);
+        insta::assert_snapshot!(format!("{}", sample), @r#"AggregatedSample { pid: 98765, tid: 98766, result: Started, ustack: "[NONE]", kstack: "[  0: kfunc2,  1: kfunc1]", count: 1001 }"#);
     }
 }


### PR DESCRIPTION
Understanding unwinding errors in profiles is not straightforward. By capturing these events and propagating them for flamegraphs, pprofs, and firefox profiles it can be in great aid in understanding when something doesn't go as expected.

Additionally this has the benefit of resulting in less biased profiles since the samples will show up with the correct weights, even if the stacks are not fully unwound.

Future work
===========

Perfetto doesn't use this field yet, this would be for another PR. Perhaps there's a better way to integrate it with this format like a metadata / event track?

Another future change would be to reuse the statuses for the various counters rather than duplicating the definitions.

Test Plan
=========

CI